### PR TITLE
Add addon usage gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export default Ember.Controller.extend({
 
 ## Usage in Addons
 
-You can also use ember-css-modules in addons that expose components to their consuming application. However, as with component templates, the styles will need to be explicitly bound to the component class, since the resolver won't be able to find them in the addon tree.
+You can also use ember-css-modules in addons that expose components to their consuming application. However, as with component templates, the styles will need to be explicitly bound to the component class, since the resolver won't be able to find them in the addon tree. You will also need to move `ember-css-modules` out of `devDependencies` and into `dependencies` in your addon's `package.json` ([see issue #8](https://github.com/salsify/ember-css-modules/issues/8)).
 
 ```js
 // addon/components/my-addon-component.js


### PR DESCRIPTION
Added instructions to usage with addons for moving the dependency to the correct place. Added because this is a non-obvious step for new Ember developers.