### PR TITLE
Allow for other addons relying on the style tree to continue to work

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,6 @@ module.exports = {
     return addon.name !== 'dummy-addon';
   },
 
-  init: function() {
-    this.modulesPreprocessor = new ModulesPreprocessor({ owner: this });
-    this.outputStylesPreprocessor = new OutputStylesPreprocessor({ owner: this });
-  },
-
   included: function(parent) {
     debug('included in %s', parent.name);
     this.options = parent.options && parent.options.cssModules || {};
@@ -27,6 +22,22 @@ module.exports = {
   setupPreprocessorRegistry: function(type, registry) {
     // Skip if we're setting up this addon's own registry
     if (type !== 'parent') { return; }
+
+    var options = registry.app.options && registry.app.options.cssModules || {};
+
+    if (!options.includeFiles) {
+      options.includeFiles = ['**/*.css'];
+    }
+
+    this.modulesPreprocessor = new ModulesPreprocessor({
+      owner: this,
+      options: options
+    });
+
+    this.outputStylesPreprocessor = new OutputStylesPreprocessor({
+      owner: this,
+      options: options
+    });
 
     registry.add('js', this.modulesPreprocessor);
     registry.add('css', this.outputStylesPreprocessor);

--- a/lib/modules-preprocessor.js
+++ b/lib/modules-preprocessor.js
@@ -11,8 +11,9 @@ var resolvePath = require('./resolve-path');
 
 module.exports = ModulesPreprocessor;
 
-function ModulesPreprocessor(options) {
-  this.owner = options.owner;
+function ModulesPreprocessor(hash) {
+  this.owner = hash.owner;
+  this.opts = hash.options;
   this.ext = this.getExtension();
   this.modulesTree = null;
 }
@@ -32,11 +33,12 @@ ModulesPreprocessor.prototype.toTree = function(inputTree, path) {
   if (path !== '/') { return inputTree; }
 
   var inputWithStyles = this.inputTreeWithStyles(inputTree);
+  var inputFiles = this.opts.includeFiles;
 
   // Hack: manually exclude stuff in tests/modules because of https://github.com/ember-cli/ember-cli-qunit/pull/96
   var modulesSources = new Funnel(inputWithStyles, {
     exclude: ['**/tests/modules/**'],
-    include: ['**/*.css']
+    include: inputFiles
   });
 
   this.modulesTree = new CSSModules(modulesSources, {

--- a/lib/output-styles-preprocessor.js
+++ b/lib/output-styles-preprocessor.js
@@ -4,25 +4,29 @@
 var debug = require('debug')('ember-css-modules:output-styles-preprocessor');
 var toposort = require('toposort');
 var Concat = require('broccoli-concat');
+var mergeTrees = require('broccoli-merge-trees');
 
 module.exports = OutputStylesPreprocessor;
 
-function OutputStylesPreprocessor(options) {
-  this.owner = options.owner;
+function OutputStylesPreprocessor(hash) {
+  this.owner = hash.owner;
+  this.opts = hash.options;
 }
 
 OutputStylesPreprocessor.prototype.constructor = OutputStylesPreprocessor;
 OutputStylesPreprocessor.prototype.toTree = function(inputNode, inputPath, outputDirectory, options) {
   var outputFile = options.outputPaths[this.owner.belongsToAddon() ? 'addon' : 'app'];
+  var includeFiles = this.opts.includeFiles;
+
   var concatOptions = {
-    inputFiles: ['**/*.css'],
+    inputFiles: includeFiles,
     outputFile: outputFile,
     allowNone: true
   };
 
   debug('concatenating module stylesheets: %o', concatOptions);
 
-  return this.dynamicHeaderConcat(concatOptions);
+  return mergeTrees([inputNode, this.dynamicHeaderConcat(concatOptions)]);
 };
 
 /*


### PR DESCRIPTION
Also adds the ability for consumers to override `includeFiles`.  Useful if they don't want certain style folders to go through css-modules.

This doesn't make ember-cli-less work with ember-css-modules, but it allows for other css/postcss preprocessors to work along side ember-css-modules.

Side note,

https://github.com/salsify/ember-css-modules/blob/master/lib/modules-preprocessor.js#L56-L63

Will become problematic where people write manipulate stylesheets in an addon, but they won't end up in css-modules because it's going around the style tree.  Unsure how to resolve this, but will look into it soon.