### PR TITLE
Htmlbar plugin preprocessor for local-class attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+## 0.3.2 Hidden Gems (May 1, 2016)
+### Fixed
+- Hidden files (e.g. `.DS_Store`) no longer break the build process (#21)
+
+### Changed
+- Final linking of `@value`s now occurs _before_ other PostCSS plugins execute (#23)
+
 ## 0.3.1 Contain Your Excitement (April 14, 2016)
 ### Fixed
 - Classes named `container` can be used once again (#15)
 
 ## 0.3.0 Location, Location, Location (Mar 31, 2016)
-
 ### Changed
 - Modules are now more intelligently ordered in the final output by default, according to composition and value dependencies. See the README for further details.
 

--- a/index.js
+++ b/index.js
@@ -2,11 +2,17 @@
 'use strict';
 
 var debug = require('debug')('ember-css-modules:addon');
+
+var HtmlbarsPlugin = require('./lib/htmlbars-plugin');
 var ModulesPreprocessor = require('./lib/modules-preprocessor');
 var OutputStylesPreprocessor = require('./lib/output-styles-preprocessor');
 
 module.exports = {
   name: 'ember-css-modules',
+
+  isDevelopingAddon: function() {
+    return true;
+  },
 
   shouldIncludeChildAddon: function(addon) {
     // Don't infinitely recurse – it's the dummy test app that depends on dummy-addon, not this addon itself
@@ -30,6 +36,10 @@ module.exports = {
 
     registry.add('js', this.modulesPreprocessor);
     registry.add('css', this.outputStylesPreprocessor);
+    registry.add('htmlbars-ast-plugin', {
+      name: 'ember-css-modules',
+      plugin: HtmlbarsPlugin
+    });
   },
 
   getScopedNameGenerator: function() {

--- a/index.js
+++ b/index.js
@@ -10,10 +10,6 @@ var OutputStylesPreprocessor = require('./lib/output-styles-preprocessor');
 module.exports = {
   name: 'ember-css-modules',
 
-  isDevelopingAddon: function() {
-    return true;
-  },
-
   shouldIncludeChildAddon: function(addon) {
     // Don't infinitely recurse – it's the dummy test app that depends on dummy-addon, not this addon itself
     return addon.name !== 'dummy-addon';

--- a/lib/htmlbars-plugin.js
+++ b/lib/htmlbars-plugin.js
@@ -1,0 +1,172 @@
+/**
+ *
+ * <button class="btn btn-sm" local-class="foo bar"></button>
+ * gets preprocessed to <button class="btn btn-sm {{styles.foo}} {{styles.bar}}">
+ *
+ */
+function Plugin() {
+  this.syntax = null
+}
+
+Plugin.prototype.constructor = Plugin;
+
+Plugin.prototype.transform = function(ast) {
+  var plugin = this;
+  var walker = new this.syntax.Walker();
+
+  walker.visit(ast, function(node) {
+    if (plugin.validate(node)) {
+      switch(node.type) {
+        case 'ElementNode':
+          plugin.parseElementNode(node);
+          break;
+        case 'MustacheStatement':
+          plugin.parseMustacheStatement(node);
+          break;
+        case 'BlockStatement':
+          plugin.parseBlockStatement(node);
+          break;
+      }
+    }
+  });
+
+  return ast;
+};
+
+Plugin.prototype.parseMustacheStatement = function(node) {
+  var localClass = findPair(node, 'local-class');
+  if (!localClass) { return; }
+
+  var classPair = findPair(node, 'class');
+
+  if (!classPair) {
+    node.hash.pairs({
+      type: 'HashPair',
+      key: 'class',
+      value: {
+        type: 'SubExpression',
+        path: {},
+        params: {},
+        hash: {}
+      }
+    });
+  }
+
+  // TODO: finish
+};
+
+Plugin.prototype.parseBlockStatement = function(node) {
+  throw new Error('not implemented.');
+};
+
+Plugin.prototype.parseElementNode = function(node) {
+  var localClassAttr = elementAttr(node, 'local-class');
+
+  if (!localClassAttr) { return; }
+
+  var classAttrNode = elementAttr(node, 'class');
+
+  if (!classAttrNode || (classAttrNode && classAttrNode.value.type !== 'ConcatStatement')) {
+    var parts = [];
+
+    if (classAttrNode) {
+      parts.push(this.transformClassAttr(classAttrNode));
+      removeAttr(node, classAttrNode);
+    }
+
+    classAttrNode = {
+      type: 'AttrNode',
+      name: 'class',
+      value: {
+        type: 'ConcatStatement',
+        parts: parts
+      }
+    };
+
+    node.attributes.push(classAttrNode);
+  }
+
+  var classAttrParts = classAttrNode.value.parts;
+
+  if (classAttrParts.length) {
+    classAttrParts.push(seperator());
+  }
+
+  localClassAttr.value.chars.split(' ').forEach(function(className) {
+    var normalizedClassName = className.trim();
+
+    classAttrParts.push({
+      type: 'PathExpression',
+      original: 'styles.' + normalizedClassName,
+      parts: ['styles', normalizedClassName]
+    });
+
+    classAttrParts.push(seperator());
+  });
+
+  removeAttr(node, localClassAttr);
+};
+
+Plugin.prototype.transformClassAttr = function(classAttrNode) {
+  var value = classAttrNode.value;
+
+  switch (value.type) {
+    case 'TextNode':
+      return {
+        type: 'StringLiteral',
+        value: value.chars,
+        original: value.chars,
+        loc: null
+      };
+    case 'MustacheStatement':
+      delete value.path.loc;
+      return value.path;
+  }
+};
+
+Plugin.prototype.validate = function(node) {
+  var type = node.type;
+
+  // BlockStatement: {{#foo-bar}}{{/foo-bar}}
+  // MustacheStatement: {{foo-bar}}
+  // ElementNode: <button></button>
+  return ['ElementNode', 'MustacheStatement'/*, 'BlockStatement'*/].indexOf(type) > -1;
+};
+
+function removeAttr(node, attribute) {
+  node.attributes.splice(node.attributes.indexOf(attribute), 1);
+}
+
+function seperator() {
+  return {
+    type: 'StringLiteral',
+    value: ' ',
+    original: ' '
+  }
+}
+
+function pushAll(target, source) {
+  for (var i=0;i<source.length;i++) {
+    target.push(source[i]);
+  }
+}
+
+function elementAttr(node, path) {
+  return findBy(node.attributes, 'name', path);
+}
+
+function findPair(node, path) {
+  return findBy(node.hash.pairs, 'key', path);
+}
+
+function findBy(target, key, path) {
+  for (var i = 0, l = target.length; i < l; i++) {
+    if (target[i][key] === path) {
+      return target[i];
+    }
+  }
+
+  return false;
+}
+
+module.exports = Plugin;

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -18,24 +18,18 @@ Plugin.prototype.transform = function(ast) {
   var walker = new this.syntax.Walker();
 
   walker.visit(ast, function(node) {
-    if (plugin.validate(node)) {
-      switch(node.type) {
-        case 'ElementNode':
-          plugin.parseElementNode(node);
-          break;
-        case 'MustacheStatement':
-        case 'BlockStatement':
-          plugin.parseStatement(node);
-          break;
-      }
+    switch(node.type) {
+      case 'ElementNode':
+        plugin.parseElementNode(node);
+        break;
+      case 'MustacheStatement':
+      case 'BlockStatement':
+        plugin.parseStatement(node);
+        break;
     }
   });
 
   return ast;
-};
-
-Plugin.prototype.validate = function(node) {
-  return ['ElementNode', 'MustacheStatement', 'BlockStatement'].indexOf(node.type) > -1;
 };
 
 Plugin.prototype.parseStatement = function(node) {
@@ -86,10 +80,10 @@ Plugin.prototype.parseElementNode = function(node) {
         parts.push(this.builders.path(classAttrValue.path.original));
       }
     }
-  }
 
-  if (parts.length) {
-    parts.push(this.seperator());
+    if (parts.length) {
+      parts.push(this.seperator());
+    }
   }
 
   this.setLocalClasses(parts, localClassAttr.value.chars);
@@ -100,6 +94,7 @@ Plugin.prototype.parseElementNode = function(node) {
 Plugin.prototype.setLocalClasses = function(target, classNames) {
   classNames.split(' ').forEach(function(className) {
     target.push(this.builders.path('styles.' + className.trim()));
+    target.push(this.seperator());
   }, this);
 };
 

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -89,7 +89,11 @@ ClassTransformPlugin.prototype.transformElementNode = function(node) {
 };
 
 ClassTransformPlugin.prototype.localToPath = function(locals) {
-  return locals.split(' ').map(function(local) {
+  var classes = locals.split(' ');
+
+  return classes.filter(function(local) {
+    return local.trim().length > 0;
+  }).map(function(local) {
     return this.builders.path('styles.' + local.trim());
   }, this);
 };

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -3,12 +3,17 @@
 var utils = require('./utils');
 
 function Plugin() {
-  this.syntax = null
+  this.syntax = null;
+  this.builders = null;
 }
 
 Plugin.prototype.constructor = Plugin;
 
 Plugin.prototype.transform = function(ast) {
+  if (!this.builders) {
+    this.builders = this.syntax.builders;
+  }
+
   var plugin = this;
   var walker = new this.syntax.Walker();
 
@@ -31,122 +36,81 @@ Plugin.prototype.transform = function(ast) {
   return ast;
 };
 
-Plugin.prototype.parseMustacheStatement = function(node) {
-  var localClassPair = utils.pair(node, 'local-class');
-  if (!localClassPair) { return; }
-  utils.removePair(node, localClassPair);
-
-  var classPair = utils.pair(node, 'class');
-  var params = [];
-
-  if (classPair) {
-    params.push(classPair.value);
-    params.push(utils.seperator());
-    utils.removePair(node, classPair);
-  }
-
-  classPair = {
-    type: 'HashPair',
-    key: 'class',
-    value: {
-      params: params,
-      type: 'SubExpression',
-      path: {
-        type: 'PathExpresison',
-        original: 'concat',
-        parts: ['concat']
-      },
-      hash: {
-        type: 'Hash',
-        pairs: []
-      }
-    }
-  };
-
-  node.hash.pairs.push(classPair);
-
-  this.localClassesToPathExpressions(localClassPair.value.value).forEach(function(exp) {
-    params.push(exp);
-    params.push(utils.seperator());
-  });
+Plugin.prototype.validate = function(node) {
+  return ['ElementNode', 'MustacheStatement'/*, 'BlockStatement'*/].indexOf(node.type) > -1;
 };
 
 Plugin.prototype.parseBlockStatement = function(node) {
   throw new Error('not implemented.');
 };
 
-Plugin.prototype.parseElementNode = function(node) {
-  var localClassAttr = utils.attr(node, 'local-class');
-  if (!localClassAttr) { return; }
-  utils.removeAttr(node, localClassAttr);
+Plugin.prototype.parseMustacheStatement = function(node) {
+  var localClassPair = utils.getPair(node, 'local-class');
 
-  var classAttrNode = utils.attr(node, 'class');
+  if (!localClassPair) { return; }
 
-  if (!classAttrNode || (classAttrNode && classAttrNode.value.type !== 'ConcatStatement')) {
-    var parts = [];
+  utils.removePair(node, localClassPair);
 
-    if (classAttrNode) {
-      parts.push(this.transformClassAttr(classAttrNode));
-      parts.push(utils.seperator());
-      utils.removeAttr(node, classAttrNode);
-    }
+  var classPair = utils.getPair(node, 'class');
+  var params = [];
 
-    classAttrNode = {
-      type: 'AttrNode',
-      name: 'class',
-      value: {
-        type: 'ConcatStatement',
-        parts: parts
-      }
-    };
-
-    node.attributes.push(classAttrNode);
+  if (classPair) {
+    params.push(classPair.value);
+    params.push(this.seperator());
+    utils.removePair(node, classPair);
   }
 
-  var classAttrParts = classAttrNode.value.parts;
-
-  this.localClassesToPathExpressions(localClassAttr.value.chars).forEach(function(exp) {
-    classAttrParts.push(exp);
-    classAttrParts.push(utils.seperator());
-  });
+  var concatSexpr = this.builders.sexpr('concat', params);
+  node.hash.pairs.push(this.builders.pair('class', concatSexpr));
+  this.setLocalClasses(params, localClassPair.value.value);
 };
 
-Plugin.prototype.transformClassAttr = function(classAttrNode) {
-  var value = classAttrNode.value;
+Plugin.prototype.parseElementNode = function(node) {
+  var localClassAttr = utils.getAttr(node, 'local-class');
+
+  if (!localClassAttr) { return; }
+
+  utils.removeAttr(node, localClassAttr);
+  var classAttr = utils.getAttr(node, 'class');
+
+  if (!classAttr || (classAttr && classAttr.value.type !== 'ConcatStatement')) {
+    var parts = [];
+
+    if (classAttr) {
+      parts.push(this.transformClassAttr(classAttr));
+      parts.push(this.seperator());
+      utils.removeAttr(node, classAttr);
+    }
+
+    classAttr = this.builders.attr('class', this.builders.concat(parts));
+    node.attributes.push(classAttr);
+  }
+
+  var classAttrParts = classAttr.value.parts;
+  classAttrParts.push(this.seperator());
+  this.setLocalClasses(classAttrParts, localClassAttr.value.chars);
+};
+
+Plugin.prototype.transformClassAttr = function(classAttr) {
+  var value = classAttr.value;
 
   switch (value.type) {
     case 'TextNode':
-      return {
-        type: 'StringLiteral',
-        value: value.chars,
-        original: value.chars,
-        loc: null
-      };
+      return this.builders.string(value.chars);
     case 'MustacheStatement':
       delete value.path.loc;
       return value.path;
   }
 };
 
-Plugin.prototype.localClassesToPathExpressions = function(classNames) {
-  return classNames.split(' ').map(function(className) {
-    var normalizedClassName = className.trim();
+Plugin.prototype.setLocalClasses = function(target, classNames) {
+  classNames.split(' ').forEach(function(className) {
+    target.push(this.builders.path('styles.' + className.trim()));
+  }, this);
+};
 
-    return {
-      type: 'PathExpression',
-      original: 'styles.' + normalizedClassName,
-      parts: ['styles', normalizedClassName]
-    };
-  });
-}
-
-Plugin.prototype.validate = function(node) {
-  var type = node.type;
-
-  // BlockStatement: {{#foo-bar}}{{/foo-bar}}
-  // MustacheStatement: {{foo-bar}}
-  // ElementNode: <button></button>
-  return ['ElementNode', 'MustacheStatement'/*, 'BlockStatement'*/].indexOf(type) > -1;
+Plugin.prototype.seperator = function() {
+  return this.builders.string(' ');
 };
 
 module.exports = Plugin;

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -2,14 +2,14 @@
 
 var utils = require('./utils');
 
-function Plugin() {
+function ClassTransformPlugin() {
   this.syntax = null;
   this.builders = null;
 }
 
-Plugin.prototype.constructor = Plugin;
+ClassTransformPlugin.prototype.constructor = ClassTransformPlugin;
 
-Plugin.prototype.transform = function(ast) {
+ClassTransformPlugin.prototype.transform = function(ast) {
   if (!this.builders) {
     this.builders = this.syntax.builders;
   }
@@ -32,9 +32,8 @@ Plugin.prototype.transform = function(ast) {
   return ast;
 };
 
-Plugin.prototype.parseStatement = function(node) {
+ClassTransformPlugin.prototype.parseStatement = function(node) {
   var localClassPair = utils.getPair(node, 'local-class');
-
   if (!localClassPair) { return; }
 
   utils.removePair(node, localClassPair);
@@ -44,18 +43,17 @@ Plugin.prototype.parseStatement = function(node) {
 
   if (classPair) {
     params.push(classPair.value);
-    params.push(this.seperator());
     utils.removePair(node, classPair);
   }
 
+  utils.pushAll(params, this.localToPath(localClassPair.value.value));
+  this.seperator(params);
   var concatSexpr = this.builders.sexpr('concat', params);
   node.hash.pairs.push(this.builders.pair('class', concatSexpr));
-  this.setLocalClasses(params, localClassPair.value.value);
 };
 
-Plugin.prototype.parseElementNode = function(node) {
+ClassTransformPlugin.prototype.parseElementNode = function(node) {
   var localClassAttr = utils.getAttr(node, 'local-class');
-
   if (!localClassAttr) { return; }
 
   utils.removeAttr(node, localClassAttr);
@@ -80,26 +78,27 @@ Plugin.prototype.parseElementNode = function(node) {
         parts.push(this.builders.path(classAttrValue.path.original));
       }
     }
-
-    if (parts.length) {
-      parts.push(this.seperator());
-    }
   }
 
-  this.setLocalClasses(parts, localClassAttr.value.chars);
-  var classAttrReplacement = this.builders.attr('class', this.builders.concat(parts));
-  node.attributes.push(classAttrReplacement);
+  utils.pushAll(parts, this.localToPath(localClassAttr.value.chars));
+  this.seperator(parts);
+  node.attributes.push(this.builders.attr('class', this.builders.concat(parts)));
 };
 
-Plugin.prototype.setLocalClasses = function(target, classNames) {
-  classNames.split(' ').forEach(function(className) {
-    target.push(this.builders.path('styles.' + className.trim()));
-    target.push(this.seperator());
+ClassTransformPlugin.prototype.localToPath = function(locals) {
+  return locals.split(' ').map(function(local) {
+    return this.builders.path('styles.' + local.trim());
   }, this);
 };
 
-Plugin.prototype.seperator = function() {
-  return this.builders.string(' ');
+ClassTransformPlugin.prototype.seperator = function(parts) {
+  for (var i=0;i<parts.length;i++) {
+    if (i % 2 === 1) {
+      parts.splice(i, 0, this.builders.string(' '));
+    }
+  }
+
+  return parts;
 };
 
-module.exports = Plugin;
+module.exports = ClassTransformPlugin;

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -1,9 +1,7 @@
-/**
- *
- * <button class="btn btn-sm" local-class="foo bar"></button>
- * gets preprocessed to <button class="btn btn-sm {{styles.foo}} {{styles.bar}}">
- *
- */
+'use strict';
+
+var utils = require('./utils');
+
 function Plugin() {
   this.syntax = null
 }
@@ -34,25 +32,43 @@ Plugin.prototype.transform = function(ast) {
 };
 
 Plugin.prototype.parseMustacheStatement = function(node) {
-  var localClass = findPair(node, 'local-class');
-  if (!localClass) { return; }
+  var localClassPair = utils.pair(node, 'local-class');
+  if (!localClassPair) { return; }
+  utils.removePair(node, localClassPair);
 
-  var classPair = findPair(node, 'class');
+  var classPair = utils.pair(node, 'class');
+  var params = [];
 
-  if (!classPair) {
-    node.hash.pairs({
-      type: 'HashPair',
-      key: 'class',
-      value: {
-        type: 'SubExpression',
-        path: {},
-        params: {},
-        hash: {}
-      }
-    });
+  if (classPair) {
+    params.push(classPair.value);
+    params.push(utils.seperator());
+    utils.removePair(node, classPair);
   }
 
-  // TODO: finish
+  classPair = {
+    type: 'HashPair',
+    key: 'class',
+    value: {
+      params: params,
+      type: 'SubExpression',
+      path: {
+        type: 'PathExpresison',
+        original: 'concat',
+        parts: ['concat']
+      },
+      hash: {
+        type: 'Hash',
+        pairs: []
+      }
+    }
+  };
+
+  node.hash.pairs.push(classPair);
+
+  this.localClassesToPathExpressions(localClassPair.value.value).forEach(function(exp) {
+    params.push(exp);
+    params.push(utils.seperator());
+  });
 };
 
 Plugin.prototype.parseBlockStatement = function(node) {
@@ -60,18 +76,19 @@ Plugin.prototype.parseBlockStatement = function(node) {
 };
 
 Plugin.prototype.parseElementNode = function(node) {
-  var localClassAttr = elementAttr(node, 'local-class');
-
+  var localClassAttr = utils.attr(node, 'local-class');
   if (!localClassAttr) { return; }
+  utils.removeAttr(node, localClassAttr);
 
-  var classAttrNode = elementAttr(node, 'class');
+  var classAttrNode = utils.attr(node, 'class');
 
   if (!classAttrNode || (classAttrNode && classAttrNode.value.type !== 'ConcatStatement')) {
     var parts = [];
 
     if (classAttrNode) {
       parts.push(this.transformClassAttr(classAttrNode));
-      removeAttr(node, classAttrNode);
+      parts.push(utils.seperator());
+      utils.removeAttr(node, classAttrNode);
     }
 
     classAttrNode = {
@@ -88,23 +105,10 @@ Plugin.prototype.parseElementNode = function(node) {
 
   var classAttrParts = classAttrNode.value.parts;
 
-  if (classAttrParts.length) {
-    classAttrParts.push(seperator());
-  }
-
-  localClassAttr.value.chars.split(' ').forEach(function(className) {
-    var normalizedClassName = className.trim();
-
-    classAttrParts.push({
-      type: 'PathExpression',
-      original: 'styles.' + normalizedClassName,
-      parts: ['styles', normalizedClassName]
-    });
-
-    classAttrParts.push(seperator());
+  this.localClassesToPathExpressions(localClassAttr.value.chars).forEach(function(exp) {
+    classAttrParts.push(exp);
+    classAttrParts.push(utils.seperator());
   });
-
-  removeAttr(node, localClassAttr);
 };
 
 Plugin.prototype.transformClassAttr = function(classAttrNode) {
@@ -124,6 +128,18 @@ Plugin.prototype.transformClassAttr = function(classAttrNode) {
   }
 };
 
+Plugin.prototype.localClassesToPathExpressions = function(classNames) {
+  return classNames.split(' ').map(function(className) {
+    var normalizedClassName = className.trim();
+
+    return {
+      type: 'PathExpression',
+      original: 'styles.' + normalizedClassName,
+      parts: ['styles', normalizedClassName]
+    };
+  });
+}
+
 Plugin.prototype.validate = function(node) {
   var type = node.type;
 
@@ -132,41 +148,5 @@ Plugin.prototype.validate = function(node) {
   // ElementNode: <button></button>
   return ['ElementNode', 'MustacheStatement'/*, 'BlockStatement'*/].indexOf(type) > -1;
 };
-
-function removeAttr(node, attribute) {
-  node.attributes.splice(node.attributes.indexOf(attribute), 1);
-}
-
-function seperator() {
-  return {
-    type: 'StringLiteral',
-    value: ' ',
-    original: ' '
-  }
-}
-
-function pushAll(target, source) {
-  for (var i=0;i<source.length;i++) {
-    target.push(source[i]);
-  }
-}
-
-function elementAttr(node, path) {
-  return findBy(node.attributes, 'name', path);
-}
-
-function findPair(node, path) {
-  return findBy(node.hash.pairs, 'key', path);
-}
-
-function findBy(target, key, path) {
-  for (var i = 0, l = target.length; i < l; i++) {
-    if (target[i][key] === path) {
-      return target[i];
-    }
-  }
-
-  return false;
-}
 
 module.exports = Plugin;

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -47,7 +47,8 @@ ClassTransformPlugin.prototype.transformStatement = function(node) {
     utils.removePair(node, classPair);
   }
 
-  utils.pushAll(params, this.localToPath(localClassPair.value.value));
+  console.log(localClassPair);
+  utils.pushAll(params, this.localToPath(localClassPair.value));
   this.divide(params);
   concatSexpr = this.builders.sexpr('concat', params);
   node.hash.pairs.push(this.builders.pair('class', concatSexpr));
@@ -83,12 +84,17 @@ ClassTransformPlugin.prototype.transformElementNode = function(node) {
     }
   }
 
-  utils.pushAll(parts, this.localToPath(localClassAttr.value.chars));
+  utils.pushAll(parts, this.localToPath(localClassAttr.value));
   this.divide(parts);
   node.attributes.push(this.builders.attr('class', this.builders.concat(parts)));
 };
 
-ClassTransformPlugin.prototype.localToPath = function(locals) {
+ClassTransformPlugin.prototype.localToPath = function(node) {
+  if (!~['StringLiteral', 'TextNode'].indexOf(node.type)) {
+    throw new TypeError('ember-css-modules - invalid type, ' + node.type + ', passed to local-class attribute.');
+  }
+
+  var locals = typeof node.chars === 'string' ? node.chars : node.value;
   var classes = locals.split(' ');
 
   return classes.filter(function(local) {

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -47,7 +47,6 @@ ClassTransformPlugin.prototype.transformStatement = function(node) {
     utils.removePair(node, classPair);
   }
 
-  console.log(localClassPair);
   utils.pushAll(params, this.localToPath(localClassPair.value));
   this.divide(params);
   concatSexpr = this.builders.sexpr('concat', params);

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -20,11 +20,11 @@ ClassTransformPlugin.prototype.transform = function(ast) {
   walker.visit(ast, function(node) {
     switch(node.type) {
       case 'ElementNode':
-        plugin.parseElementNode(node);
+        plugin.transformElementNode(node);
         break;
       case 'MustacheStatement':
       case 'BlockStatement':
-        plugin.parseStatement(node);
+        plugin.transformStatement(node);
         break;
     }
   });
@@ -32,7 +32,7 @@ ClassTransformPlugin.prototype.transform = function(ast) {
   return ast;
 };
 
-ClassTransformPlugin.prototype.parseStatement = function(node) {
+ClassTransformPlugin.prototype.transformStatement = function(node) {
   var localClassPair = utils.getPair(node, 'local-class');
   if (!localClassPair) { return; }
 
@@ -40,6 +40,7 @@ ClassTransformPlugin.prototype.parseStatement = function(node) {
 
   var classPair = utils.getPair(node, 'class');
   var params = [];
+  var concatSexpr;
 
   if (classPair) {
     params.push(classPair.value);
@@ -47,12 +48,12 @@ ClassTransformPlugin.prototype.parseStatement = function(node) {
   }
 
   utils.pushAll(params, this.localToPath(localClassPair.value.value));
-  this.seperator(params);
-  var concatSexpr = this.builders.sexpr('concat', params);
+  this.divide(params);
+  concatSexpr = this.builders.sexpr('concat', params);
   node.hash.pairs.push(this.builders.pair('class', concatSexpr));
 };
 
-ClassTransformPlugin.prototype.parseElementNode = function(node) {
+ClassTransformPlugin.prototype.transformElementNode = function(node) {
   var localClassAttr = utils.getAttr(node, 'local-class');
   if (!localClassAttr) { return; }
 
@@ -60,15 +61,17 @@ ClassTransformPlugin.prototype.parseElementNode = function(node) {
 
   var classAttr = utils.getAttr(node, 'class');
   var parts = [];
+  var classAttrValue
 
   if (classAttr) {
     utils.removeAttr(node, classAttr);
+    classAttrValue = classAttr.value;
 
-    var classAttrValue = classAttr.value;
-
-    // Unwrap the original class attribute value
+    // Unwrap the original class attribute value and transform
+    // the attr value into parts that make up the ConcatStatement
+    // that is returned from this method
     if (classAttrValue.type === 'ConcatStatement') {
-      parts = parts.concat(classAttrValue.parts);
+      parts.push(this.builders.sexpr('concat', classAttrValue.parts));
     } else if (classAttrValue.type === 'TextNode') {
       parts.push(this.builders.string(classAttrValue.chars));
     } else if (classAttrValue.type === 'MustacheStatement') {
@@ -81,7 +84,7 @@ ClassTransformPlugin.prototype.parseElementNode = function(node) {
   }
 
   utils.pushAll(parts, this.localToPath(localClassAttr.value.chars));
-  this.seperator(parts);
+  this.divide(parts);
   node.attributes.push(this.builders.attr('class', this.builders.concat(parts)));
 };
 
@@ -91,7 +94,7 @@ ClassTransformPlugin.prototype.localToPath = function(locals) {
   }, this);
 };
 
-ClassTransformPlugin.prototype.seperator = function(parts) {
+ClassTransformPlugin.prototype.divide = function(parts) {
   for (var i=0;i<parts.length;i++) {
     if (i % 2 === 1) {
       parts.splice(i, 0, this.builders.string(' '));

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -65,36 +65,36 @@ Plugin.prototype.parseElementNode = function(node) {
   if (!localClassAttr) { return; }
 
   utils.removeAttr(node, localClassAttr);
+
   var classAttr = utils.getAttr(node, 'class');
+  var parts = [];
 
-  if (!classAttr || (classAttr && classAttr.value.type !== 'ConcatStatement')) {
-    var parts = [];
+  if (classAttr) {
+    utils.removeAttr(node, classAttr);
 
-    if (classAttr) {
-      parts.push(this.transformClassAttr(classAttr));
-      parts.push(this.seperator());
-      utils.removeAttr(node, classAttr);
+    var classAttrValue = classAttr.value;
+
+    // Unwrap the original class attribute value
+    if (classAttrValue.type === 'ConcatStatement') {
+      parts = parts.concat(classAttrValue.parts);
+    } else if (classAttrValue.type === 'TextNode') {
+      parts.push(this.builders.string(classAttrValue.chars));
+    } else if (classAttrValue.type === 'MustacheStatement') {
+      if (classAttrValue.params.length) {
+        parts.push(classAttrValue);
+      } else {
+        parts.push(this.builders.path(classAttrValue.path.original));
+      }
     }
-
-    classAttr = this.builders.attr('class', this.builders.concat(parts));
-    node.attributes.push(classAttr);
   }
 
-  var classAttrParts = classAttr.value.parts;
-  classAttrParts.push(this.seperator());
-  this.setLocalClasses(classAttrParts, localClassAttr.value.chars);
-};
-
-Plugin.prototype.transformClassAttr = function(classAttr) {
-  var value = classAttr.value;
-
-  switch (value.type) {
-    case 'TextNode':
-      return this.builders.string(value.chars);
-    case 'MustacheStatement':
-      delete value.path.loc;
-      return value.path;
+  if (parts.length) {
+    parts.push(this.seperator());
   }
+
+  this.setLocalClasses(parts, localClassAttr.value.chars);
+  var classAttrReplacement = this.builders.attr('class', this.builders.concat(parts));
+  node.attributes.push(classAttrReplacement);
 };
 
 Plugin.prototype.setLocalClasses = function(target, classNames) {

--- a/lib/htmlbars-plugin/index.js
+++ b/lib/htmlbars-plugin/index.js
@@ -24,10 +24,8 @@ Plugin.prototype.transform = function(ast) {
           plugin.parseElementNode(node);
           break;
         case 'MustacheStatement':
-          plugin.parseMustacheStatement(node);
-          break;
         case 'BlockStatement':
-          plugin.parseBlockStatement(node);
+          plugin.parseStatement(node);
           break;
       }
     }
@@ -37,14 +35,10 @@ Plugin.prototype.transform = function(ast) {
 };
 
 Plugin.prototype.validate = function(node) {
-  return ['ElementNode', 'MustacheStatement'/*, 'BlockStatement'*/].indexOf(node.type) > -1;
+  return ['ElementNode', 'MustacheStatement', 'BlockStatement'].indexOf(node.type) > -1;
 };
 
-Plugin.prototype.parseBlockStatement = function(node) {
-  throw new Error('not implemented.');
-};
-
-Plugin.prototype.parseMustacheStatement = function(node) {
+Plugin.prototype.parseStatement = function(node) {
   var localClassPair = utils.getPair(node, 'local-class');
 
   if (!localClassPair) { return; }

--- a/lib/htmlbars-plugin/utils.js
+++ b/lib/htmlbars-plugin/utils.js
@@ -1,0 +1,43 @@
+'use strict';
+
+function removeAttr(node, attribute) {
+  node.attributes.splice(node.attributes.indexOf(attribute), 1);
+}
+
+function removePair(node, pair) {
+  node.hash.pairs.splice(node.hash.pairs.indexOf(pair), 1);
+}
+
+function seperator() {
+  return {
+    type: 'StringLiteral',
+    value: ' ',
+    original: ' '
+  };
+}
+
+function attr(node, path) {
+  return findBy(node.attributes, 'name', path);
+}
+
+function pair(node, path) {
+  return findBy(node.hash.pairs, 'key', path);
+}
+
+function findBy(target, key, path) {
+  for (var i = 0, l = target.length; i < l; i++) {
+    if (target[i][key] === path) {
+      return target[i];
+    }
+  }
+
+  return false;
+}
+
+module.exports = {
+  pair: pair,
+  attr: attr,
+  seperator: seperator,
+  removePair: removePair,
+  removeAttr: removeAttr
+}

--- a/lib/htmlbars-plugin/utils.js
+++ b/lib/htmlbars-plugin/utils.js
@@ -8,19 +8,11 @@ function removePair(node, pair) {
   node.hash.pairs.splice(node.hash.pairs.indexOf(pair), 1);
 }
 
-function seperator() {
-  return {
-    type: 'StringLiteral',
-    value: ' ',
-    original: ' '
-  };
-}
-
-function attr(node, path) {
+function getAttr(node, path) {
   return findBy(node.attributes, 'name', path);
 }
 
-function pair(node, path) {
+function getPair(node, path) {
   return findBy(node.hash.pairs, 'key', path);
 }
 
@@ -35,9 +27,8 @@ function findBy(target, key, path) {
 }
 
 module.exports = {
-  pair: pair,
-  attr: attr,
-  seperator: seperator,
+  getPair: getPair,
+  getAttr: getAttr,
   removePair: removePair,
   removeAttr: removeAttr
 }

--- a/lib/htmlbars-plugin/utils.js
+++ b/lib/htmlbars-plugin/utils.js
@@ -26,7 +26,16 @@ function findBy(target, key, path) {
   return false;
 }
 
+function pushAll(target, arr) {
+  for (var i=0;i<arr.length;i++) {
+    target.push(arr[i]);
+  }
+
+  return target;
+}
+
 module.exports = {
+  pushAll: pushAll,
   getPair: getPair,
   getAttr: getAttr,
   removePair: removePair,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "ember server",
     "test": "npm run test-lib && npm run test-ember",
     "test-ember": "ember try:each",
-    "test-lib": "tape tests-node/**/*-test.js"
+    "test-lib": "./node_modules/tape/bin/tape tests-node/**/*-test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "ember server",
     "test": "npm run test-lib && npm run test-ember",
     "test-ember": "ember try:each",
-    "test-lib": "./node_modules/tape/bin/tape tests-node/**/*-test.js"
+    "test-lib": "tape tests-node/**/*-test.js"
   },
   "repository": {
     "type": "git",

--- a/tests-node/htmlbars-plugin-test.js
+++ b/tests-node/htmlbars-plugin-test.js
@@ -14,6 +14,12 @@ testTransformation('appending to a class attribute', {
   elementOutput: 'class="x {{styles.foo}}"'
 });
 
+testTransformation('appending to a class attribute #2', {
+  input: 'class=x local-class="foo"',
+  statementOutput: 'class=(concat x " " styles.foo)',
+  elementOutput: 'class="x {{styles.foo}}"'
+});
+
 // ...
 
 function testTransformation(title, options) {


### PR DESCRIPTION
Work in progress, but just opening it for exposure while I iterate on it.  I still need to implement support for `MustacheStatements` and `BlockStatements`.

Currently supported on `ElementNodes`:

```hbs
<button local-class="btn">Submit</button>
<button class="foo" local-class="btn">Submit</button>
<button class={{foo}} local-class="btn">Submit</button>
<button class="{{foo}}" local-class="btn">Submit</button>

{{#x-input class="btn" local-class="field input"}}...{{/x-input}}
{{x-input class="btn" local-class="field inout"}}
```

Gets preprocessed to:

```hbs
<button class="{{styles.btn}}">Submit</button>
<button class="foo {{styles.btn}}">Submit</button>
<button class="{{foo}} {{styles.btn}}">Submit</button>
<button class="{{foo}} {{styles.btn}}">Submit</button>

{{#x-foo class=(concat 'btn' styles.field styles.input)}}...{{/x-input}}
{{x-foo class=(concat 'btn' styles.field styles.input)}}
```

https://github.com/salsify/ember-css-modules/issues/1

* [x] ElementNode
* [x] MustacheStatement
* [x] BlockStatement
* [x] Fix `<div class={{concat 'foo' 'bar'}} local-class="root">..</div>`
* [x] Test coverage