### PR TITLE
Use a glob to configure the path of the CSS modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # dependencies
 /node_modules
 /bower_components
+/tests/dummy-less-addon/node_modules
+/tests/dummy-sass-addon/node_modules
 
 # misc
 /.sass-cache

--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ module.exports = {
     return this.options.plugins || [];
   },
 
+  getFilePath () {
+    return this.options && this.options.path || ('**/*.' + this.getFileExtension());
+  },
+
   getFileExtension: function() {
     return this.options && this.options.extension || 'css';
   },

--- a/lib/modules-preprocessor.js
+++ b/lib/modules-preprocessor.js
@@ -35,7 +35,7 @@ ModulesPreprocessor.prototype.toTree = function(inputTree, path) {
   // Hack: manually exclude stuff in tests/modules because of https://github.com/ember-cli/ember-cli-qunit/pull/96
   var modulesSources = new Funnel(inputWithStyles, {
     exclude: ['**/tests/modules/**'],
-    include: ['**/*.' + this.owner.getFileExtension()]
+    include: [this.owner.getFilePath()]
   });
 
   this.modulesTree = new CSSModules(modulesSources, {


### PR DESCRIPTION
Use a glob to specify the path of CSS modules, this allows us to create CSS modules in a different path which helps a lot with migrations from normal SASS to CSS modules SASS for example.

Not entirely sure how to write a test for this, any suggestions?