### PR TITLE
Handle undefined local-class

### DIFF
--- a/addon/helpers/local-class.js
+++ b/addon/helpers/local-class.js
@@ -5,7 +5,7 @@ export function localClass(params, hash) {
   if (!hash.from) { return ''; }
 
   let styles = resolveSource(hash.from);
-  let classes = params[0].split(/\s+/);
+  let classes = (params[0] || '').split(/\s+/);
 
   return classes.map(style => styles[style]).filter(Boolean).join(' ');
 }

--- a/tests/unit/helpers/local-class-test.js
+++ b/tests/unit/helpers/local-class-test.js
@@ -48,6 +48,10 @@ test('with an empty source specified', function(assert) {
   assert.equal(localClass(['abc'], { from: null }), '');
 });
 
+test('with an undefined local class', function(assert) {
+  assert.equal(localClass([undefined], { from: null }), '');
+});
+
 export default { foo: '_foo_123', bar: '_bar_789' };
 
 test('with a string source specified', function(assert) {


### PR DESCRIPTION
If we do something like 

```
local-class=(if foo 'active')
```

and foo is false, ember-css-modules will attempt to split on `undefined`. This PR fixes this issue by defaulting to an empty string.