### PR TITLE
Run before ember-cli-postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
       "ember-cli-babel",
       "ember-cli-less",
       "ember-cli-sass",
-      "ember-cli-stylus"
+      "ember-cli-stylus",
+      "ember-cli-postcss"
     ],
     "versionCompatibility": {
       "ember": ">=2.0.0 <3.0.0"


### PR DESCRIPTION
Same logic as for why there is scheduling to run before ember-cli-sass & ember-cli-less.