### PR TITLE
Prevent classNameBindings on tag-less component

### DIFF
--- a/addon/mixins/component-mixin.js
+++ b/addon/mixins/component-mixin.js
@@ -11,6 +11,9 @@ export default Ember.Mixin.create({
 
   init() {
     this._super();
+
+    if (this.tagName === '') return;
+
     this.classNameBindings = [
       ...this.classNameBindings,
       ...localClassNames(this),


### PR DESCRIPTION
Hi,

I was trying to use this addon within an existing project with `liquid-fire`. I stumble upon this error:

```
Assertion Failed: You cannot use `classNameBindings` on a tag-less component: <peakapp@component:liquid-outlet::ember235>
```

The problem is, that [`liquid-fire` use `tagName: ''` on its `outlet`](https://github.com/ember-animation/liquid-fire/blob/56156c599a4fed6c6db8572f85092ed07f91f2c8/addon/components/liquid-outlet.js#L12) and this addon doesn’t seem to like it :) The following solution fixed the issue in my app and I haven’t seen any downside. If you feel this is not the correct fix, feel free to guide me in the correct direction.

Keep up the good work!

✌️ 