### PR TITLE
Fixes to work with corber / any package without keywords

### DIFF
--- a/lib/plugin/registry.js
+++ b/lib/plugin/registry.js
@@ -36,7 +36,9 @@ module.exports = class PluginRegistry {
   }
 
   _isPlugin(addon) {
-    return addon.pkg.keywords.indexOf('ember-css-modules-plugin') >= 0;
+    return addon.pkg 
+      && addon.pkg.keywords
+      && addon.pkg.keywords.indexOf('ember-css-modules-plugin') >= 0;
   }
 
   _instantiatePluginFor(addon) {


### PR DESCRIPTION
Corber creates a tree in which it has a live-reload pkg that looks like this

```

{ treeFor: [Function: treeFor],
  pkg: { 'ember-addon': {} },
  root: 'corber-livereload',
  name: 'corber-livereload',
  addons: [],
```

This breaks that line in the registry as it expects every package to have keywords