### PR TITLE
fix(package): run after ember-font-awesome

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
+    "after": [
+      "ember-font-awesome"
+    ],
     "before": [
       "ember-cli-babel",
       "ember-cli-less",


### PR DESCRIPTION
This makes `{{fa-icon iconName local-class="some-icon"}}` compatible with ember-font-awesome@v4, which now uses an HTMLBars AST transform to replace all invocations of `{{fa-icon}}` with a plain HTML `<i>` tag.

Ironically ember-css-modules has to be included *after* ember-font-awesome in order for its transforms to run before ember-font-awesome.

I have absolutely no idea why though. ¯\_(ツ)_/¯