### PR TITLE
Attribute ember-osf-web as the basis for the decorators implementation

### DIFF
--- a/addon/decorators.js
+++ b/addon/decorators.js
@@ -1,3 +1,10 @@
+/*
+  The implementation of these decorators is based on the original work of the
+  ember-osf-web project, released under the Apache License 2.0:
+
+  https://github.com/CenterForOpenScience/ember-osf-web/blob/4675920c4d53e60c62eed7a87ea84e0f4c5ab018/app/decorators/css-modules.ts
+*/
+
 import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { decoratorWithParams } from '@ember-decorators/utils/decorator';


### PR DESCRIPTION
As correctly pointed out in https://github.com/salsify/ember-css-modules/pull/101#issuecomment-423204133, the implementation of these decorators is based on the original work of [ember-osf-web](https://github.com/CenterForOpenScience/ember-osf-web/blob/4675920c4d53e60c62eed7a87ea84e0f4c5ab018/app/decorators/css-modules.ts), which is released under the Apache License 2.0, which allows reuse in derivative works (such as this), but requires attribution. In order to comply with this license, this PR adds the attribution as comment in the source code.

/cc @binoculars