### PR TITLE
feat(plugins): pass `includer` as second param

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -13,13 +13,15 @@ const Plugin = require('ember-css-modules/lib/plugin');
 module.exports = {
   name: 'ember-css-modules-super-cool-plugin',
 
-  createCssModulesPlugin(parent) {
-    return new Plugin(parent);
+  createCssModulesPlugin(parent, includer) {
+    return new Plugin(parent, includer);
   }
 }
 ```
 
 The `createCssModulesPlugin` method receives a reference to the plugin's parent, which is either a [`Project`](https://ember-cli.com/api/classes/Project.html) or an [`Addon`](https://ember-cli.com/api/classes/Addon.html), depending on whether the plugin was included by an app or an addon, respectively.
+
+It also receives the direct [`includer`](https://ember-cli.com/api/classes/Addon.html#method_included) as a second parameter.
 
 This isn't a particularly exciting example, though, as it doesn't actually do anything. To have any impact on the build, a plugin needs to implement one or more of the available hooks.
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = {
   included(includer) {
     debug('included in %s', includer.name);
     this.ownerName = includer.name;
-    this.plugins = new PluginRegistry(this.parent);
+    this.plugins = new PluginRegistry(this.parent, includer);
     this.cssModulesOptions = this.plugins.computeOptions(includer.options && includer.options.cssModules);
 
     if (this.belongsToAddon()) {

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -3,8 +3,9 @@
 const normalizePostcssPlugins = require('../utils/normalize-postcss-plugins');
 
 module.exports = class Plugin {
-  constructor(parent) {
+  constructor(parent, includer) {
     this.parent = parent;
+    this.includer = includer;
   }
 
   isForApp() {

--- a/lib/plugin/registry.js
+++ b/lib/plugin/registry.js
@@ -8,8 +8,9 @@ const debug = require('debug')('ember-css-modules:plugin-registry');
 const normalizePostcssPlugins = require('../utils/normalize-postcss-plugins');
 
 module.exports = class PluginRegistry {
-  constructor(parent) {
+  constructor(parent, includer) {
     this.parent = parent;
+    this.includer = includer;
     this.plugins = this._instantiatePlugins();
   }
 
@@ -58,7 +59,7 @@ module.exports = class PluginRegistry {
   _instantiatePluginFor(addon) {
     debug('instantiating plugin %s', addon.name);
 
-    const plugin = addon.createCssModulesPlugin(this.parent);
+    const plugin = addon.createCssModulesPlugin(this.parent, this.includer);
     if (!(plugin instanceof Plugin)) {
       this.parent.ui.writeWarnLine(
         `Addon ${addon.name} did not return a Plugin instance from its createCssModulesPlugin hook`


### PR DESCRIPTION
I want to be able to access the build config (`ember-cli-build.js`), when my addon / plugin is included directly by a host app.

In this case however `this.parent` is a [`Project`](https://ember-cli.com/api/classes/Project.html), which has no connection to the [`EmberApp`](https://ember-cli.com/api/classes/EmberApp.html).

I _think_ we shouldn't pass through `this.parent`, but instead the `parent` param (`includer`) of [`included(parent)`](https://ember-cli.com/api/classes/Addon.html#method_included). However, this would be a breaking change, which is why made `includer` an additional parameter.

What do you think?

I am currently working around this via `this.app` like so:

```ts
  computeOptions(includer: Addon | Project | EmberApp) {
    if (!includer.options && !this.app)
      throw new Error('Could not find parent options.');

    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
    const parentOptions = includer.options || this.app!.options;

    this.addonOptions = computeOptions(parentOptions.foo);
    }
  },

  createCssModulesPlugin(parent: Addon | Project) {
    this.computeOptions(parent);

    return new EmberCSSModulesPlugin(parent, this);
  }
```