### PR TITLE
fix: support template factory

### DIFF
--- a/addon/mixins/component-mixin.js
+++ b/addon/mixins/component-mixin.js
@@ -42,6 +42,9 @@ export default Mixin.create({
       layout
     );
 
+    // Since https://github.com/emberjs/ember.js/pull/18096
+    if (typeof layout === 'function') layout = layout(getOwner(this));
+
     // This is not public API and might break at any time...
     let moduleName = (layout.meta || layout.referrer).moduleName.replace(/\.hbs$/, '');
     if (/\/template$/.test(moduleName)) {


### PR DESCRIPTION
https://github.com/emberjs/ember.js/pull/18096

This PR changed how templates are used under the hood. Template modules now export a factory function that expects to be called with the `owner`.