### PR TITLE
Failing test for component global scope

### DIFF
--- a/packages/ember-css-modules/tests/acceptance/styles-lookup-test.js
+++ b/packages/ember-css-modules/tests/acceptance/styles-lookup-test.js
@@ -14,6 +14,7 @@ module('Acceptance | styles lookup', function() {
     'pod-route/nested-pod-component',
     'pod-route/nested-pod-template-only-component',
     'component-with-dynamic-local-class',
+    'component-with-global-scope',
     'component-with-global-class-and-dynamic-local-class',
     'component-with-local-class-helper',
     'component-with-global-class-composition',

--- a/packages/ember-css-modules/tests/dummy/app/components/testing/component-with-global-scope/styles.css
+++ b/packages/ember-css-modules/tests/dummy/app/components/testing/component-with-global-scope/styles.css
@@ -1,0 +1,5 @@
+:global {
+  .global-scope-class {
+    font-family: 'component-with-global-class-composition';
+  }
+}

--- a/packages/ember-css-modules/tests/dummy/app/components/testing/component-with-global-scope/template.hbs
+++ b/packages/ember-css-modules/tests/dummy/app/components/testing/component-with-global-scope/template.hbs
@@ -1,0 +1,1 @@
+<div class="global-scope-class" data-test-element>component with global scope</div>


### PR DESCRIPTION
I get that this isn't an ideal use case, but it would make migration _worlds_ easier.