### PR TITLE
docs(postcss): add Babel-like config format

### DIFF
--- a/docs/POSTCSS.md
+++ b/docs/POSTCSS.md
@@ -18,7 +18,9 @@ new EmberApp(defaults, {
 });
 ```
 
-## Before/After PostCSS Plugins
+## Processing Order
+
+### `before` / `after` PostCSS Plugins
 
 By default, any PostCSS plugins you specify will be applied after the module transformation. To apply a set of plugins beforehand instead, you can pass a hash with `before` and `after` keys. For instance, if you wanted to use [postcss-nested](https://github.com/postcss/postcss-nested) so that you could define a set of global classes as a single block:
 
@@ -37,7 +39,7 @@ new EmberApp(defaults, {
 });
 ```
 
-## Post-Process Plugins
+### `postprocess` Plugins
 
 You can also provide a set of `postprocess` plugins that will run on the file after it has been concatenated.  This is useful for plugins like `postcss-sprites` that behave better when run against a single file. The `postprocess` array will be passed through to the `plugins` option in [`broccoli-postcss`](https://github.com/jeffjewiss/broccoli-postcss#broccolipostcsstree-options); see that package for details.
 
@@ -52,6 +54,41 @@ new EmberApp(defaults, {
   }
 });
 ```
+
+## Configuring Plugins with Options
+
+Most PostCSS plugins can optionally be configured. Conventionally, you can:
+
+- either pass a plugin as is, to not set any options
+- or call it first to provide options.
+
+```javascript
+new EmberApp(defaults, {
+  cssModules: {
+    plugins: [
+      require('postcss-calc') // without any further config
+      require('postcss-preset-env')({ stage: 4 }) // with extra config
+    ]
+  }
+});
+```
+
+ember-css-modules also supports a Babel-like way to configure plugins:
+
+```javascript
+new EmberApp(defaults, {
+  cssModules: {
+    plugins: [
+      require('postcss-calc'), // without any further config
+      [require('postcss-preset-env'), { stage: 4 }] // with extra config
+    ]
+  }
+});
+```
+
+This special config format is useful, if you are using multiple
+[ember-css-modules plugins](./PLUGINS.md), that would like to inter-operate with
+one another and collaboratively construct a final config.
 
 ## Importing Third Party Files
 


### PR DESCRIPTION
This PR adds a Babel-like PostCSS plugin config format.

```javascript
new EmberApp(defaults, {
  cssModules: {
    plugins: [
      require('postcss-calc'), // without any further config
      [require('postcss-preset-env'), { stage: 4 }] // with extra config
    ]
  }
});
```

This format, compared to the standard config format, allows ember-css-modules plugins to patch the config for PostCSS plugins. This is very useful for plugins like [`postcss-mixins`](https://github.com/postcss/postcss-mixins), so that multiple ember-css-modules plugins can add mixin definitions to the same `postcss-mixins` instance. This would fix: https://github.com/postcss/postcss-mixins/issues/104

The alternative for me would be to have a "main" ember-css-modules plugin that adds `postcss-mixins` and has something like a mini plugin registry itself, so that other ember-css-modules plugins can hook in there. This seems unnecessarily complex to me though.