### PR TITLE
Document beta version requirement for colocation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Similarly, if you were styling e.g. your application controller, you would mirro
 
 ### Component Colocation in Octane Applications
 
+**Note:** you need the beta version for component template colocation support:
+```
+ember install ember-css-modules@1.3.0-beta1
+```
+
 In Octane apps, where component templates can be colocated with their backing class, your styles module for a component takes the same name as the backing class and template files:
 
 ```hbs

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Similarly, if you were styling e.g. your application controller, you would mirro
 
 ### Component Colocation in Octane Applications
 
-**Note:** you need the beta version for component template colocation support:
+**Note:** you currently need the beta version for component template colocation support:
 ```
-ember install ember-css-modules@1.3.0-beta1
+ember install ember-css-modules@1.3.0-beta.1
 ```
 
 In Octane apps, where component templates can be colocated with their backing class, your styles module for a component takes the same name as the backing class and template files:


### PR DESCRIPTION
Support for Octane-style colocation exists, but currently only in the beta version.

This PR adds a note to the README to help people understand that, until the obstacles to supporting it in the stable version are addressed.

Related: #151.