### PR TITLE
[Fix] Usage through addon

### DIFF
--- a/packages/ember-css-modules/index.js
+++ b/packages/ember-css-modules/index.js
@@ -21,6 +21,11 @@ module.exports = {
 
   init() {
     this._super.init && this._super.init.apply(this, arguments);
+
+    if (this.belongsToAddon()) {
+      this.parentAddon = this.getParent();
+    }
+
     this.modulesPreprocessor = new ModulesPreprocessor({ owner: this });
     this.outputStylesPreprocessor = new OutputStylesPreprocessor({ owner: this });
     this.checker = new VersionChecker(this.project);
@@ -32,7 +37,6 @@ module.exports = {
 
     if (this.belongsToAddon()) {
       this.verifyStylesDirectory();
-      this.parentAddon = includer;
     }
 
     this._super.included.apply(this, arguments);


### PR DESCRIPTION
## Issue
I've created a addon that aims to provide a set of styles to reuse across apps, this does makes use of `ember-css-modules`. The problem is that there were cli errors preventing the build on line: https://github.com/salsify/ember-css-modules/blob/master/packages/ember-css-modules/index.js#L153

## Analysis
There error was caused because `this.parentAddon` was undefined. Looking at the stack trace,  it appears that `getParentAddonTree` is called here:
https://github.com/salsify/ember-css-modules/blob/master/packages/ember-css-modules/lib/modules-preprocessor.js#L31
which happens because we're instantiating here:
https://github.com/salsify/ember-css-modules/blob/master/packages/ember-css-modules/index.js#L24
This is still the `init` hook, which happens earlier than 
https://github.com/salsify/ember-css-modules/blob/master/packages/ember-css-modules/index.js#L35
where the missing property is actually declared.

## Proposed solution
By simply defining `this.parentAddon` before we need inside `ModulesPreprocessor`, did the trick. Using `this.getParent()` is effectively equivalent to the `includer`(parent) parameter on `included()`. 

## QA
Tested with yarn link only:
- Everything works as expected using the addon on a single app.
- Everything works as expected using the addon as part of another addon's `dependencies`, effectively passing down `ember-css-modules` to the app without any errors.