### PR TITLE
Restore 1.2.x timing for config calculation

### DIFF
--- a/docs/VIRTUAL_MODULES.md
+++ b/docs/VIRTUAL_MODULES.md
@@ -23,19 +23,21 @@ The following import would retrieve the value `#4dbd33`:
 Virtual modules may be particularly useful for addon authors, as they provide a way to make your addon styling configurable by consumers of your addon at build time. For instance, in your `index.js` you might have something like:
 
 ```js
-included() {
-  // ...
-  this.options = Object.assign({}, this.options, {
-    cssModules: {
-      virtualModules: {
-        'my-addon-config': {
-          'header-color': config.headerColor || 'green',
-          'header-background': config.headerBackground || 'gray'
+setupPreprocessorRegistry(target) {
+  if (target === 'parent') {
+    let includingAppOrAddon = this.app || this.parent;
+    let config = includingAppOrAddon.options.mySpecialConfig || {};
+
+    this.options = Object.assign({}, this.options, {
+      cssModules: {
+        virtualModules: {
+          'my-addon-config': {
+            'header-color': config.headerColor || 'green',
+            'header-background': config.headerBackground || 'gray'
+          }
         }
       }
-    }
-  });
-  this._super.included.apply(this, arguments);
-  // ...
+    });
+  }
 }
 ```

--- a/docs/VIRTUAL_MODULES.md
+++ b/docs/VIRTUAL_MODULES.md
@@ -23,21 +23,19 @@ The following import would retrieve the value `#4dbd33`:
 Virtual modules may be particularly useful for addon authors, as they provide a way to make your addon styling configurable by consumers of your addon at build time. For instance, in your `index.js` you might have something like:
 
 ```js
-setupPreprocessorRegistry(target) {
-  if (target === 'parent') {
-    let includingAppOrAddon = this.app || this.parent;
-    let config = includingAppOrAddon.options.mySpecialConfig || {};
-
-    this.options = Object.assign({}, this.options, {
-      cssModules: {
-        virtualModules: {
-          'my-addon-config': {
-            'header-color': config.headerColor || 'green',
-            'header-background': config.headerBackground || 'gray'
-          }
+included() {
+  // ...
+  this.options = Object.assign({}, this.options, {
+    cssModules: {
+      virtualModules: {
+        'my-addon-config': {
+          'header-color': config.headerColor || 'green',
+          'header-background': config.headerBackground || 'gray'
         }
       }
-    });
-  }
+    }
+  });
+  this._super.included.apply(this, arguments);
+  // ...
 }
 ```

--- a/packages/ember-css-modules/lib/resolve-path.js
+++ b/packages/ember-css-modules/lib/resolve-path.js
@@ -11,7 +11,7 @@ module.exports = function resolvePath(importPath, fromFile, options) {
   } else if (isLocalPath(pathWithExtension, options)) {
     return resolveLocalPath(pathWithExtension, fromFile, options);
   } else {
-    return resolveExternalPath(pathWithExtension, options);
+    return resolveExternalPath(pathWithExtension, importPath, fromFile, options);
   }
 };
 
@@ -37,13 +37,16 @@ function resolveLocalPath(importPath, fromFile, options) {
 }
 
 // Resolve absolute paths pointing to external addons
-function resolveExternalPath(importPath, options) {
+function resolveExternalPath(importPath, originalPath, fromFile, options) {
   let baseIndex = importPath[0] === '@' ? importPath.indexOf('/') + 1 : 0;
   let addonName = importPath.substring(0, importPath.indexOf('/', baseIndex));
   let addon = options.parent.addons.find(addon => addon.name === addonName);
 
   if (!addon) {
-    throw new Error(`Unable to resolve styles from addon ${addonName}; is it installed?`);
+    throw new Error(
+      `Unable to resolve styles module '${originalPath}' imported from '${fromFile}'. ` +
+      `No virtual module with that name was defined and no corresponding addon was found.`
+    );
   }
 
   let pathWithinAddon = importPath.substring(addonName.length + 1);


### PR DESCRIPTION
This will fix #166 (or at least the original error reported there). Now, a typo in an import path will no longer give the cryptic error message:

```
Unable to resolve styles from addon ; is it installed?
```

Instead, devs will see:

```
Unable to resolve styles module 'oops/a/typo' imported from
'<importing file>.css'. No virtual module with that name was
defined and no corresponding addon was found.
```

It also updates the guidance in the virtual modules documentation due to the config calculation timing changes that were necessary to support component/template colocation.