### PR TITLE
Ensure local imports work with CLI 3.12

### DIFF
--- a/packages/ember-css-modules/lib/resolve-path.js
+++ b/packages/ember-css-modules/lib/resolve-path.js
@@ -31,6 +31,15 @@ function resolveRelativePath(importPath, fromFile, options) {
 // Resolve absolute paths pointing to the same app/addon as the importer
 function resolveLocalPath(importPath, fromFile, options) {
   let appOrAddonDirIndex = fromFile.indexOf(options.ownerName, options.root.length);
+
+  // Depending on the exact version of Ember CLI and/or Embroider in play, the
+  // app/addon name may or may not be included in `fromFile`'s path. If not, we
+  // need to strip that prefix from the import path.
+  if (appOrAddonDirIndex === -1) {
+    appOrAddonDirIndex = options.root.length;
+    importPath = ensurePosixPath(importPath).replace(new RegExp('^' + options.ownerName + '/?'), '');
+  }
+
   let prefix = fromFile.substring(0, appOrAddonDirIndex);
   let absolutePath = ensurePosixPath(path.resolve(prefix, importPath));
   return internalDep(absolutePath, options);


### PR DESCRIPTION
Exactly how modules are presented within a broccoli tree varies pretty widely over different ember-cli versions, and while adding Embroider to the mix will hopefully eventually simplify that, in the short term it just means one more set of behaviors we have to juggle. ECM 1.3.0 apparently broke resolution of absolute intra-package imports for some range of ember-cli versions newer than the oldest we support, but older than 3.13, as @jamescdavis discovered.