### PR TITLE
Ensure ember-css-modules inits before ember-cli-htmlbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2 (August 28, 2020)
+### Fixed
+- Ensure `ember-css-modules` is initialized before `ember-cli-htmlbars`. This almost always was coincidentally the case already, but ordering constraints from other addons _could_ cause ECM to init later, causing `local-class` in colocated templates not to be processed, as in [ember-concurrency-async#4](https://github.com/chancancode/ember-concurrency-async/issues/4)
+
 ## 1.3.1 (May 26, 2020)
 ### Fixed
 - Ensure local imports work with CLI 3.12 [#197](https://github.com/salsify/ember-css-modules/pull/197)

--- a/packages/ember-css-modules/package.json
+++ b/packages/ember-css-modules/package.json
@@ -94,6 +94,7 @@
     ],
     "before": [
       "ember-cli-babel",
+      "ember-cli-htmlbars",
       "ember-cli-less",
       "ember-cli-sass",
       "ember-cli-stylus",


### PR DESCRIPTION
This PR ensures that `ember-css-modules` is initialized before `ember-cli-htmlbars`.

This almost always was coincidentally the case already, but ordering constraints from other addons _could_ cause ECM to init later, causing `local-class` in colocated templates not to be processed.

This _should_ fix chancancode/ember-concurrency-async#4.