### PR TITLE
Addons default to the root app's `generateScopedName` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,8 @@ new EmberApp(defaults, {
 });
 ```
 
+Note that addons may specify their own `generateScopedName` function, but otherwise they will fall back to using the one (if any) specified by the host application.
+
 ### Source Maps
 
 Ember CLI allows you to [specify source map settings](https://ember-cli.com/user-guide/#source-maps) for your entire build process, and ember-css-modules will honor that configuration. For instance, to enable source maps in all environments for both JS and CSS files, you could put the following in your `ember-cli-build.js`:

--- a/packages/ember-css-modules/index.js
+++ b/packages/ember-css-modules/index.js
@@ -115,7 +115,14 @@ module.exports = {
   },
 
   getScopedNameGenerator() {
-    return this.cssModulesOptions.generateScopedName || require('./lib/generate-scoped-name');
+    if (!this._scopedNameGenerator) {
+      let rootOptions = this._findRootApp().options.cssModules || {};
+      this._scopedNameGenerator = this.cssModulesOptions.generateScopedName
+        || rootOptions.generateScopedName
+        || require('./lib/generate-scoped-name');
+    }
+
+    return this._scopedNameGenerator;
   },
 
   getModuleRelativePath(fullPath) {


### PR DESCRIPTION
This PR updates behavior so that addons using ECM that don't specify their own `generateScopedName` will use the host app's config if any is specified, rather than immediately falling back to the default implementation.

This makes it possible for apps to configure scoped name generation universally without having to figure out a way to plumb that information through to individual subpackages.