### PR TITLE
Support localClassNames in classic colocated components

### DIFF
--- a/packages/ember-css-modules/addon/mixins/component-mixin.js
+++ b/packages/ember-css-modules/addon/mixins/component-mixin.js
@@ -51,9 +51,9 @@ export default Mixin.create({
       return tryLoad(moduleName.replace(/template$/, 'styles'));
     } else if (/\/templates\//.test(moduleName)) {
       return tryLoad(moduleName.replace('/templates/', '/styles/'));
+    } else {
+      return tryLoad(`${moduleName}.css`);
     }
-
-    return;
   })
 });
 

--- a/test-packages/dummy-addon/addon/components/testing/classic-colocated-component.css
+++ b/test-packages/dummy-addon/addon/components/testing/classic-colocated-component.css
@@ -1,0 +1,3 @@
+.component-class {
+  font-family: 'classic-colocated-component';
+}

--- a/test-packages/dummy-addon/addon/components/testing/classic-colocated-component.hbs
+++ b/test-packages/dummy-addon/addon/components/testing/classic-colocated-component.hbs
@@ -1,0 +1,1 @@
+classic colocated component

--- a/test-packages/dummy-addon/addon/components/testing/classic-colocated-component.js
+++ b/test-packages/dummy-addon/addon/components/testing/classic-colocated-component.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  localClassNames: ['component-class'],
+  attributeBindings: ['dataTest:data-test-element'],
+  dataTest: true,
+});

--- a/test-packages/dummy-addon/app/components/testing/classic-colocated-component.js
+++ b/test-packages/dummy-addon/app/components/testing/classic-colocated-component.js
@@ -1,0 +1,1 @@
+export { default } from 'dummy-addon/components/testing/classic-colocated-component';

--- a/test-packages/dummy-addon/tests/integration/styles-lookup-test.js
+++ b/test-packages/dummy-addon/tests/integration/styles-lookup-test.js
@@ -8,6 +8,7 @@ module('Integration | component styles lookup', function(hooks) {
 
   const components = [
     'addon-component',
+    'classic-colocated-component',
     'component-with-addon-value',
     'component-with-addon-composition'
   ];


### PR DESCRIPTION
Fixes #179

This is sort of WIP because I don't think this will work if `extension` is set to something different like `scss`. I couldn't find a way to get access to this from the context of the mixin declaration:

https://github.com/salsify/ember-css-modules/blob/b932ee753bd1bcef775e0c58c4a865816c782de1/packages/ember-css-modules/index.js#L152-L154

Any pointers will be appreciated