### PR TITLE
Ensure styles tree has been processed before checking its outputPath

### DIFF
--- a/packages/ember-css-modules/lib/modules-preprocessor.js
+++ b/packages/ember-css-modules/lib/modules-preprocessor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Funnel = require('broccoli-funnel');
+const { Funnel } = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
 const Bridge = require('broccoli-bridge');
 const ensurePosixPath = require('ensure-posix-path');
@@ -223,8 +223,7 @@ function formatJS(classMapping) {
 
 class ModuleSourceFunnel extends Funnel {
   constructor(input, stylesTree, options) {
-    super(input, options);
-    this.stylesTree = stylesTree;
+    super([input, stylesTree], options);
     this.parentName = options.parentName;
     this.destDir = options.outputRoot;
     this.inputHasParentName = null;
@@ -239,7 +238,8 @@ class ModuleSourceFunnel extends Funnel {
     if (this.inputHasParentName === null) {
       this.inputHasParentName = fs.existsSync(`${this.inputPaths[0]}/${this.parentName}`);
 
-      let stylesTreeHasParentName = fs.existsSync(`${this.stylesTree.outputPath}/${this.parentName}`);
+      let stylesTreePath = this.inputPaths[1];
+      let stylesTreeHasParentName = fs.existsSync(`${stylesTreePath}/${this.parentName}`);
       if (stylesTreeHasParentName && !this.inputHasParentName) {
         this.destDir += `/${this.parentName}`;
       }

--- a/packages/ember-css-modules/lib/output-styles-preprocessor.js
+++ b/packages/ember-css-modules/lib/output-styles-preprocessor.js
@@ -4,7 +4,7 @@ const debug = require('debug')('ember-css-modules:output-styles-preprocessor');
 const Concat = require('broccoli-concat');
 const MergeTrees = require('broccoli-merge-trees');
 const PostCSS = require('broccoli-postcss');
-const Funnel = require('broccoli-funnel');
+const { Funnel } = require('broccoli-funnel');
 
 module.exports = class OutputStylesPreprocessor {
   constructor(options) {

--- a/packages/ember-css-modules/package.json
+++ b/packages/ember-css-modules/package.json
@@ -72,7 +72,7 @@
     "broccoli-bridge": "^1.0.0",
     "broccoli-concat": "^3.2.2",
     "broccoli-css-modules": "^0.7.0 || ^0.8.0",
-    "broccoli-funnel": "^2.0.1",
+    "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-postcss": "^4.0.1 || ^5.0.0 || ^6.0.0",
     "calculate-cache-key-for-tree": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3816,36 +3816,30 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.5.tgz#60da33d060fae2936b3d78217bd4008a6eea5e41"
-  integrity sha512-fcjvQIWq4lpKyzQ7FWRo/V8/nOALjIrAoRMFCLgFeO2xhOC1+i7QWbMndLTwpnLCoXpTa+luBu3WSFoxQ3VPlw==
+broccoli-funnel@^3.0.0, broccoli-funnel@^3.0.3:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.7.tgz#003c1e90e15f2416ccaad7a12667bfeaed843123"
+  integrity sha512-DuiMqbR3eHY/c5ctOd0d/aqiGcY3r8Ynoz12vxTsEp5vRkFaIRuMhz5w7UHJbMcoC9nMNnY9hGrvVFODngPRXw==
   dependencies:
     array-equal "^1.0.0"
-    blank-object "^1.0.1"
     broccoli-plugin "^4.0.7"
     debug "^4.1.1"
-    fast-ordered-set "^1.0.0"
     fs-tree-diff "^2.0.1"
     heimdalljs "^0.2.0"
     minimatch "^3.0.0"
-    path-posix "^1.0.0"
     walk-sync "^2.0.2"
 
-broccoli-funnel@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz#26fd42632471f67a91f4770d1987118087219937"
-  integrity sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==
+broccoli-funnel@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz#f5b62e2763c3918026a15a3c833edc889971279b"
+  integrity sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==
   dependencies:
     array-equal "^1.0.0"
-    blank-object "^1.0.1"
-    broccoli-plugin "^4.0.1"
+    broccoli-plugin "^4.0.7"
     debug "^4.1.1"
-    fast-ordered-set "^1.0.0"
     fs-tree-diff "^2.0.1"
     heimdalljs "^0.2.0"
     minimatch "^3.0.0"
-    path-posix "^1.0.0"
     walk-sync "^2.0.2"
 
 broccoli-kitchen-sink-helpers@^0.2.5:
@@ -6621,12 +6615,12 @@ ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1, ember-co
     semver "^5.4.1"
 
 "ember-css-modules@link:packages/ember-css-modules":
-  version "1.3.4"
+  version "1.4.0"
   dependencies:
     broccoli-bridge "^1.0.0"
     broccoli-concat "^3.2.2"
     broccoli-css-modules "^0.7.0 || ^0.8.0"
-    broccoli-funnel "^2.0.1"
+    broccoli-funnel "^3.0.8"
     broccoli-merge-trees "^2.0.0"
     broccoli-postcss "^4.0.1 || ^5.0.0 || ^6.0.0"
     calculate-cache-key-for-tree "^1.1.0"


### PR DESCRIPTION
Prior to this change, the `ModuleSourceFunnel` would assume that the passed in `stylesTree` has been processed when its `build` hook was called. This _happened_ to work in some cases, but since Broccoli builder uses a DAG to decide what order to build trees in it absolutely could find a different sort order that causes `ModuleSourceFunnel` to run before that styles tree.

As part of this, I updated broccoli-funnel to allow `super`ing with either a single node (prior behavior) or an array (https://github.com/broccolijs/broccoli-funnel/pull/146). broccoli-funnel itself will never look at ainputs other than `inputPath[0]` but this is useful to ensure the broccoli node graph indicates the required ordering.

---

This fixes an error in Embroider builds where ember-css-modules is a child of an engine. The error you might get in that scenario is:

```
Build Error (OneShot)

BroccoliPlugin: this.outputPath is only accessible once the build has begun.
        at ModuleSourceFunnel
```
