### PR TITLE
ember-cli-version-checker 5 compat

### DIFF
--- a/packages/ember-css-modules/index.js
+++ b/packages/ember-css-modules/index.js
@@ -76,7 +76,7 @@ module.exports = {
     }
 
     this.parentPreprocessorRegistry.add('htmlbars-ast-plugin', HtmlbarsPlugin.instantiate({
-      emberVersion: this.checker.forEmber().version,
+      emberVersion: this.checker.for('ember-source', 'npm').version,
       options: {
         fileExtension: this.getFileExtension(),
         includeExtensionInModulePath: this.includeExtensionInModulePath(),

--- a/packages/ember-css-modules/package.json
+++ b/packages/ember-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-css-modules",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "CSS Modules for ambitious applications",
   "scripts": {
     "build": "ember build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,7 +6621,7 @@ ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1, ember-co
     semver "^5.4.1"
 
 "ember-css-modules@link:packages/ember-css-modules":
-  version "1.3.4"
+  version "1.4.1"
   dependencies:
     broccoli-bridge "^1.0.0"
     broccoli-concat "^3.2.2"


### PR DESCRIPTION
[ember-cli-version-checker 5.0.0](https://github.com/ember-cli/ember-cli-version-checker/blob/master/CHANGELOG.md#v500-2020-02-14) dropped `checker.forEmber` in favor of just using `checker.for('ember-source', 'npm')` directly: https://github.com/ember-cli/ember-cli-version-checker/pull/165

Note: the `'npm'` param isn't necessary in ember-cli-version-checker 5.x, but keeping it ensures compatibility back to 2.x