### PR TITLE
fixes resolve-path logic for finding local paths that include an addon's name

### DIFF
--- a/packages/ember-css-modules/lib/resolve-path.js
+++ b/packages/ember-css-modules/lib/resolve-path.js
@@ -44,18 +44,16 @@ function resolveRelativePath(importPath, fromFile, options) {
 
 // Resolve absolute paths pointing to the same app/addon as the importer
 function resolveLocalPath(importPath, fromFile, options) {
-  let appOrAddonDirIndex = fromFile.indexOf(options.ownerName, options.root.length);
+  const fromFileStartsWithOwnerName = fromFile.substring(options.root.length + 1).startsWith(options.ownerName);
 
   // Depending on the exact version of Ember CLI and/or Embroider in play, the
   // app/addon name may or may not be included in `fromFile`'s path. If not, we
   // need to strip that prefix from the import path.
-  if (appOrAddonDirIndex === -1) {
-    appOrAddonDirIndex = options.root.length;
-    importPath = ensurePosixPath(importPath).replace(new RegExp('^' + options.ownerName + '/?'), '');
+  if (!fromFileStartsWithOwnerName) {
+    importPath = importPath.substring(options.ownerName.length + 1);
   }
 
-  let prefix = fromFile.substring(0, appOrAddonDirIndex);
-  let absolutePath = ensurePosixPath(path.resolve(prefix, importPath));
+  let absolutePath = ensurePosixPath(path.resolve(options.root, importPath));
   return internalDep(absolutePath, options);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,7 +6621,7 @@ ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1, ember-co
     semver "^5.4.1"
 
 "ember-css-modules@link:packages/ember-css-modules":
-  version "1.4.0"
+  version "1.5.0"
   dependencies:
     broccoli-bridge "^1.0.0"
     broccoli-concat "^3.2.2"


### PR DESCRIPTION
Right now, if a component file includes the name of its containing addon, the old logic would find that `appOrAddonDirIndex` would not be `-1`, when in reality it should be.

EX: addon name is `special-button`
```css
/* special-button/addon/components/special-button.css */

.special-button {
  composes: special from 'special-button/components/base-specialness';
}
```

With parameters like this (this is how it looks in our embroider build):
```js
importPath        === 'special-button/components/base-specialness';
fromFile          === '/tmp/broccoli-4392qIAomevRxZbJ/out-03-module_source_funnel/components/special-button.css';
options.root      === '/tmp/broccoli-4392qIAomevRxZbJ/out-03-module_source_funnel/';
options.ownerName === 'special-button';
```

In the old logic, we would get something like:

```js
let appOrAddonDirIndex = fromFile.indexOf(options.ownerName, options.root.length)
// where
options.root.length === 59;
// so it's searching this string: 'components/special-button.css' for 'special-button' and the result is:
appOrAddonDirIndex === 70;
// then we get to the line:
let prefix = fromFile.substring(0, appOrAddonDirIndex);
prefix === 'special-button.css'
// and the line
let absolutePath = ensurePosixPath(path.resolve(prefix, importPath));
// is trying to resolve
'special-button.css/special-button/components/base-specialness';
// which obviously won't exist
```

the new code follows more closely with the intent of what was being done here:

```js
// we want to check that after the root ( plus one char for '/'), the fromFile starts with the ownerName
// const fromFileStartsWithOwner = fromFile.substring(options.root.length + 1).startsWith(options.ownerName);
const fromFileStartsWithOwner = 'components/special-button.css'.startsWith('special-button')
// so
fromFileStartsWithOwner === false
// because the portion of fromFile after the owner.root does not start with ownerName, we need to remove the ownerName (plus a '/') from the importPath
importPath = importPath.substring(options.ownerName.length+1);
importPath === 'components/base-specialness';
// now, rather than needing a prefix, we can always use the root, and the new importPath
// so we can try to resolve:
'/tmp/broccoli-4392qIAomevRxZbJ/out-03-module_source_funnel/components/base-specialness.css';
// which should actually exist if that file exists in the addon.
```