### PR TITLE
Allow to opt out of classic component patching

### DIFF
--- a/packages/ember-css-modules/index.js
+++ b/packages/ember-css-modules/index.js
@@ -43,7 +43,13 @@ module.exports = {
 
   treeForAddon() {
     let addonTree = this._super.treeForAddon.apply(this, arguments);
-    return new MergeTrees([addonTree, `${__dirname}/vendor`]);
+
+    // Allow to opt-out from automatic Component.reopen()
+    if (this.cssModulesOptions.patchClassicComponent !== false) {
+      return new MergeTrees([addonTree, `${__dirname}/vendor`]);
+    } else {
+      return addonTree;
+    }
   },
 
   cacheKeyForTree(treeType) {


### PR DESCRIPTION
opt-in to address #237 until a breaking release is made.

This would allow you to specify:

```js
  let app = new EmberAddon(defaults, {
    cssModules: {
      patchClassicComponent: false
    }
  });
```

Avoid the deprecation `Reopening the Ember.Component super class itself is deprecated` if you do not use classic components (or the bindings on classic components, at least).

Thanks to @Turbo87 and @mydea for idea.

Closes #237.