### PR TITLE
Introduce scopeBehaviour css-modules option

### DIFF
--- a/packages/ember-css-modules/index.js
+++ b/packages/ember-css-modules/index.js
@@ -164,6 +164,10 @@ module.exports = {
     return this.cssModulesOptions.postcssOptions;
   },
 
+  getScopeBehaviour() {
+    return this.cssModulesOptions.scopeBehaviour;
+  },
+
   getParentAddonTree() {
     return path.join(this.parentAddon.root, this.parentAddon.treePaths.addon);
   },

--- a/packages/ember-css-modules/lib/modules-preprocessor.js
+++ b/packages/ember-css-modules/lib/modules-preprocessor.js
@@ -71,6 +71,7 @@ module.exports = class ModulesPreprocessor {
         enableSourceMaps: this.owner.enableSourceMaps(),
         sourceMapBaseDir: '',
         postcssOptions: this.owner.getPostcssOptions(),
+        scopeBehaviour: this.owner.getScopeBehaviour(),
         virtualModules: this.owner.getVirtualModules(),
         generateScopedName: this.scopedNameGenerator(),
         resolvePath: this.resolveAndRecordPath.bind(this),


### PR DESCRIPTION
We're looking to use ember-css-modules for our large apps. We'll be migrating away from ember-component-css. In order to do that seamlessly, we need to turn off behavior for localizing every selector. We want to localize explicitly via `:local(.component) { ... }` syntax. So I thought I'd propose this change here to this addon. Basically after this one could say `scopeBehaviour: 'global'` in the config and achieve the behavior I'm talking about.

This is inspired by original postcss-modules option, documented here: https://github.com/madyankin/postcss-modules/tree/v6.0.0#generating-scoped-names
See this issue for the context: https://github.com/madyankin/postcss-modules/issues/22#issue-143777964

Seems like they had it since 2016 so I hope this change to this addon would be welcome as well. If this is approved, I can add documentation.

Related PR to the broccoli-css-modules: https://github.com/salsify/broccoli-css-modules/pull/27