### PR TITLE
Fixes deprecated usage of `node.path.orignal` in `htmlbars-plugin`

### DIFF
--- a/packages/ember-css-modules/lib/htmlbars-plugin/index.js
+++ b/packages/ember-css-modules/lib/htmlbars-plugin/index.js
@@ -62,7 +62,7 @@ module.exports = class ClassTransformPlugin {
   }
 
   transformStatement(node) {
-    if (node.path.original === 'local-class') {
+    if (!this.isNodePathLiteral(node.path) && node.path.original === 'local-class') {
       this.transformLocalClassHelperInvocation(node);
     } else {
       this.transformPossibleComponentInvocation(node);
@@ -70,7 +70,7 @@ module.exports = class ClassTransformPlugin {
   }
 
   transformSubexpression(node) {
-    if (node.path.original === 'local-class') {
+    if (!this.isNodePathLiteral(node.path) && node.path.original === 'local-class') {
       this.transformLocalClassHelperInvocation(node);
     }
   }
@@ -244,5 +244,15 @@ module.exports = class ClassTransformPlugin {
     }
 
     return parts;
+  }
+
+  isNodePathLiteral(path) {
+    return {
+      StringLiteral: true,
+      BooleanLiteral: true,
+      NumberLiteral: true,
+      UndefinedLiteral: true,
+      NullLiteral: true
+    }[path.type] ?? false;
   }
 };


### PR DESCRIPTION
The `original` property on literal nodes is deprecated: https://github.com/glimmerjs/glimmer-vm/blob/10eae7429b702b1e7f5434b91802d5767ff7ad9a/packages/%40glimmer/syntax/lib/v1/legacy-interop.ts#L130

This PR adds a check to see whether the path is one of the literal node paths, and if so does not access the `original` property