### PR TITLE
Fix .original deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 2.1.1 (April 4, 2019)
+### Fixed
+- Remove usage of .original in Ember 5.9+ to fix deprecation warnings.
+
 ## 2.1.0 (April 2, 2024)
 
 ### Added

--- a/packages/ember-css-modules/lib/htmlbars-plugin/index.js
+++ b/packages/ember-css-modules/lib/htmlbars-plugin/index.js
@@ -62,7 +62,7 @@ module.exports = class ClassTransformPlugin {
   }
 
   transformStatement(node) {
-    if (node.path.original === 'local-class') {
+    if (getValue(node.path) === 'local-class') {
       this.transformLocalClassHelperInvocation(node);
     } else {
       this.transformPossibleComponentInvocation(node);
@@ -70,7 +70,7 @@ module.exports = class ClassTransformPlugin {
   }
 
   transformSubexpression(node) {
-    if (node.path.original === 'local-class') {
+    if (getValue(node.path) === 'local-class') {
       this.transformLocalClassHelperInvocation(node);
     }
   }
@@ -246,3 +246,17 @@ module.exports = class ClassTransformPlugin {
     return parts;
   }
 };
+
+function getValue(path) {
+  if (!path) return;
+
+  if ('value' in path) {
+    return path.value;
+  }
+
+  /**
+   * Deprecated in ember 5.9+
+   * (so we use the above for newer embers)
+   */
+  return path.original;
+}

--- a/packages/ember-css-modules/lib/htmlbars-plugin/utils.js
+++ b/packages/ember-css-modules/lib/htmlbars-plugin/utils.js
@@ -21,7 +21,7 @@ function updateStringValue(node, updater) {
     node.chars = updater(node.chars);
   } else if (node.type === 'StringLiteral') {
     node.value = updater(node.value);
-    node.original = updater(node.original);
+    getValue(node) = updater(getValue(node));
   } else {
     throw new Error('Unknown node type ' + node.type + ' (not a string?)');
   }
@@ -74,6 +74,20 @@ function pushAll(target, arr) {
   }
 
   return target;
+}
+
+function getValue(path) {
+  if (!path) return;
+
+  if ('value' in path) {
+    return path.value;
+  }
+
+  /**
+   * Deprecated in ember 5.9+
+   * (so we use the above for newer embers)
+   */
+  return path.original;
 }
 
 module.exports = {

--- a/packages/ember-css-modules/lib/htmlbars-plugin/utils.js
+++ b/packages/ember-css-modules/lib/htmlbars-plugin/utils.js
@@ -21,7 +21,7 @@ function updateStringValue(node, updater) {
     node.chars = updater(node.chars);
   } else if (node.type === 'StringLiteral') {
     node.value = updater(node.value);
-    getValue(node) = updater(getValue(node));
+    setValue(node, updater(getValue(node)));
   } else {
     throw new Error('Unknown node type ' + node.type + ' (not a string?)');
   }
@@ -88,6 +88,20 @@ function getValue(path) {
    * (so we use the above for newer embers)
    */
   return path.original;
+}
+
+function setValue(node, value) {
+  if (!node) return;
+
+  if ('value' in node) {
+    node.value = value;
+  } else {
+    /**
+     * Deprecated in ember 5.9+
+     * (so we use the above for newer embers)
+     */
+    path.original = value;
+  }
 }
 
 module.exports = {

--- a/packages/ember-css-modules/package.json
+++ b/packages/ember-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-css-modules",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CSS Modules for ambitious applications",
   "scripts": {
     "build": "ember build --environment=production",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5873,7 +5873,7 @@ ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-co
     semver "^5.4.1"
 
 "ember-css-modules@link:packages/ember-css-modules":
-  version "2.0.1"
+  version "2.1.1"
   dependencies:
     broccoli-bridge "^1.0.0"
     broccoli-concat "^4.2.5"


### PR DESCRIPTION
This causes a lot of deprecation spew when using Ember > 5.9. I am open to other fixes, but this is how I fixed it in ember-cp-validations.