### PR TITLE
Fix classNames runtime helper for undefined and unmapped classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+- Handle `undefined`/`null`/empty string passed to `classNames()` runtime helper [#335](https://github.com/salsify/ember-css-modules/pull/335)
+- Drop unmapped class names in `classNames()` instead of passing them through, matching v2 behavior [#335](https://github.com/salsify/ember-css-modules/pull/335)
+
 ## 2.1.1 (April 4, 2019)
 ### Fixed
 - Remove usage of .original in Ember 5.9+ to fix deprecation warnings.

--- a/packages/glimmer-local-class-transform/src/runtime.test.ts
+++ b/packages/glimmer-local-class-transform/src/runtime.test.ts
@@ -8,6 +8,12 @@ describe('Runtime helpers', () => {
     expect(classNames({ foo: 'bar' }, '  foo    baz ')).toBe('bar baz');
   });
 
+  test('classNames with undefined or empty classes', () => {
+    expect(classNames({}, undefined as unknown as string)).toBe('');
+    expect(classNames({}, null as unknown as string)).toBe('');
+    expect(classNames({}, '')).toBe('');
+  });
+
   test('join', () => {
     expect(join()).toBe('');
     expect(join('foo')).toBe('foo');

--- a/packages/glimmer-local-class-transform/src/runtime.test.ts
+++ b/packages/glimmer-local-class-transform/src/runtime.test.ts
@@ -3,9 +3,9 @@ import { join, classNames } from './runtime.js';
 
 describe('Runtime helpers', () => {
   test('classNames', () => {
-    expect(classNames({}, 'foo')).toBe('foo');
+    expect(classNames({}, 'foo')).toBe('');
     expect(classNames({ foo: 'bar' }, 'foo')).toBe('bar');
-    expect(classNames({ foo: 'bar' }, '  foo    baz ')).toBe('bar baz');
+    expect(classNames({ foo: 'bar' }, '  foo    baz ')).toBe('bar');
   });
 
   test('classNames with undefined or empty classes', () => {

--- a/packages/glimmer-local-class-transform/src/runtime.ts
+++ b/packages/glimmer-local-class-transform/src/runtime.ts
@@ -1,4 +1,6 @@
 export function classNames(mapping: Record<string, string>, classes: string): string {
+  if (!classes) return '';
+
   return classes
     .trim()
     .split(/\s+/)

--- a/packages/glimmer-local-class-transform/src/runtime.ts
+++ b/packages/glimmer-local-class-transform/src/runtime.ts
@@ -4,7 +4,8 @@ export function classNames(mapping: Record<string, string>, classes: string): st
   return classes
     .trim()
     .split(/\s+/)
-    .map((className) => mapping[className] ?? className)
+    .map((className) => mapping[className])
+    .filter(Boolean)
     .join(' ');
 }
 


### PR DESCRIPTION
## Summary
- Guard against `undefined`/`null`/empty string being passed to `classNames()` in the runtime helper — previously threw `TypeError: Cannot read properties of undefined (reading 'trim')`
- Drop unmapped class names instead of passing them through — the `??` fallback in `classNames()` was passing unknown classes (e.g. global utility classes like `.is-hidden`) to the DOM, which changed behavior from v2 where they were silently dropped. This caused issues like CSS transitions breaking when global `display: none` classes were unexpectedly applied.

## Test plan
- [x] `vitest run` passes for runtime tests (3/3)
- [x] CI green on fork: https://github.com/deanmarano/ember-css-modules/pull/2
- [x] All tests passing in consuming app

See also: https://github.com/salsify/ember-css-modules/issues/318