### PR TITLE
Add migration guides and package READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+- Migration guides for apps and addons moving from `ember-css-modules` to the standalone packages [#338](https://github.com/salsify/ember-css-modules/pull/338)
+
 ### Fixed
 - Handle `undefined`/`null`/empty string passed to `classNames()` runtime helper [#335](https://github.com/salsify/ember-css-modules/pull/335)
 - Drop unmapped class names in `classNames()` instead of passing them through, matching v2 behavior [#335](https://github.com/salsify/ember-css-modules/pull/335)

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ For details on developing your own, see the [plugins mini-guide](docs/PLUGINS.md
 
 You can find a list of all publicly available plugins by browsing [the npm `ember-css-modules-plugin` keyword](https://www.npmjs.com/browse/keyword/ember-css-modules-plugin).
 
+## Migration Guides
+
+- [Migrating an App from ember-css-modules (v1 → v2)](docs/MIGRATING-V1-APP.md)
+- [Migrating an Addon from ember-css-modules (v1 → v2)](docs/MIGRATING-V1-ADDON.md)
+
 ## Advanced Configuration
 
 Details about specific advanced configuration options are broken out into smaller mini-guides that each focus on a single topic:

--- a/docs/MIGRATING-V1-ADDON.md
+++ b/docs/MIGRATING-V1-ADDON.md
@@ -1,0 +1,141 @@
+# Migrating an Addon from ember-css-modules to v2 format
+
+This guide covers migrating the CSS Modules portion of an Ember addon from v1 (with `ember-css-modules`) to v2 format (with `glimmer-local-class-transform` and `rollup-plugin-preprocess-css-modules`).
+
+## Prerequisites
+
+You should be familiar with the v2 addon format generally. This guide covers only the CSS Modules portion of the migration. For the broader v1-to-v2 addon migration, see the [Embroider v2 addon guide](https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md).
+
+## Steps
+
+### 1. Swap dependencies
+
+Remove `ember-css-modules` from `dependencies`. Add the new packages:
+
+```sh
+npm uninstall ember-css-modules
+npm install --save glimmer-local-class-transform
+npm install --save-dev rollup-plugin-preprocess-css-modules
+```
+
+`glimmer-local-class-transform` goes in `dependencies` because consuming apps need it at build time. `rollup-plugin-preprocess-css-modules` is only used to build the addon, so it goes in `devDependencies`.
+
+### 2. Create `babel.publish.config.cjs`
+
+This Babel config is used when building the addon for publication. It must include `glimmer-local-class-transform` in the template compilation transforms, with `targetFormat: 'hbs'` so that templates are compiled to `.hbs` (which Rollup and the consuming app can process):
+
+```js
+// babel.publish.config.cjs
+module.exports = {
+  plugins: [
+    '@embroider/addon-dev/template-colocation-plugin',
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        targetFormat: 'hbs',
+        transforms: ['glimmer-local-class-transform'],
+      },
+    ],
+    [
+      'module:decorator-transforms',
+      {
+        runtime: {
+          import: 'decorator-transforms/runtime-esm',
+        },
+      },
+    ],
+  ],
+
+  generatorOpts: {
+    compact: false,
+  },
+};
+```
+
+### 3. Update Rollup config
+
+Add `preprocessCSSModules()` to your Rollup plugins, include `.hbs` in the Babel extensions, and use `addon.keepAssets(['**/*.css'])` to preserve the CSS output:
+
+```js
+// rollup.config.mjs
+import { babel } from '@rollup/plugin-babel';
+import { Addon } from '@embroider/addon-dev/rollup';
+import { preprocessCSSModules } from 'rollup-plugin-preprocess-css-modules';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+export default {
+  output: addon.output(),
+
+  plugins: [
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
+    addon.dependencies(),
+
+    babel({
+      extensions: ['.hbs', '.js', '.gjs'],
+      babelHelpers: 'bundled',
+      configFile: './babel.publish.config.cjs',
+    }),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript.
+    addon.gjs(),
+
+    // Preprocess CSS Modules so consumers get plain CSS.
+    preprocessCSSModules(),
+
+    // Keep CSS files in the published output.
+    addon.keepAssets(['**/*.css']),
+
+    addon.clean(),
+  ],
+};
+```
+
+### 4. Move and rename files
+
+Move your component files from `addon/` to `src/` (standard v2 addon layout) and rename CSS files to `.module.css`:
+
+```
+addon/components/my-component.hbs → src/components/my-component.hbs
+addon/components/my-component.js  → src/components/my-component.js
+addon/components/my-component.css → src/components/my-component.module.css
+```
+
+You can also remove `addon/styles/.placeholder` — it was only needed by `ember-css-modules` to trigger CSS processing in the classic build.
+
+Remove the `app/` re-export files (e.g. `app/components/my-component.js`) — v2 addons handle re-exports via `addon.appReexports()` in the Rollup config.
+
+### 5. Template syntax
+
+No changes needed. `local-class` works identically:
+
+```hbs
+<div local-class="my-class">{{yield}}</div>
+<div local-class={{this.dynamicClass}}>{{yield}}</div>
+```
+
+## What `rollup-plugin-preprocess-css-modules` does
+
+In a v2 addon, CSS Modules are an implementation detail — consuming apps shouldn't need to know or care that your addon uses them internally.
+
+`rollup-plugin-preprocess-css-modules` handles this by preprocessing `.module.css` imports at build time. It:
+
+1. Processes each `.module.css` file through CSS Modules, generating scoped class names.
+2. Replaces the JavaScript `import styles from './my-component.module.css'` (which `glimmer-local-class-transform` generates) with a static object mapping original class names to their scoped equivalents.
+3. Outputs a plain `.css` file with the scoped class names already applied.
+
+The result is that your published addon contains only standard CSS and JS — no CSS Modules runtime is needed by consumers.
+
+See the [`rollup-plugin-preprocess-css-modules` README](../packages/rollup-plugin-preprocess-css-modules/README.md) for configuration options like `generateScopedName` and `getOutputFilename`.

--- a/docs/MIGRATING-V1-ADDON.md
+++ b/docs/MIGRATING-V1-ADDON.md
@@ -2,11 +2,60 @@
 
 This guide covers migrating the CSS Modules portion of an Ember addon from v1 (with `ember-css-modules`) to v2 format (with `glimmer-local-class-transform` and `rollup-plugin-preprocess-css-modules`).
 
+The migration can be done in stages. Some preparation steps can be done while the addon is still in v1 format, reducing the amount of change needed in the final conversion.
+
 ## Prerequisites
 
 You should be familiar with the v2 addon format generally. This guide covers only the CSS Modules portion of the migration. For the broader v1-to-v2 addon migration, see the [Embroider v2 addon guide](https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md).
 
-## Steps
+## Preparation (can be done before converting to v2)
+
+These steps work with `ember-css-modules` while the addon is still in v1 format. Each produces a working addon.
+
+### Consolidate to colocated file layout
+
+If you have components using pod layout (`component/styles.css`) or classic layout (`styles/components/foo.css`), move them to colocated files alongside the component's template/JS. `ember-css-modules` already supports colocated layout:
+
+**Pod layout → colocated:**
+
+```
+addon/components/my-component/styles.css → addon/components/my-component.css
+```
+
+**Classic layout → colocated:**
+
+```
+addon/styles/components/my-component.css → addon/components/my-component.css
+```
+
+This step can be done one component at a time.
+
+### Rename CSS files to `.module.css`
+
+`ember-css-modules` supports configuring the file extension via the addon's `index.js`. You can rename your CSS files to `.module.css` now — matching the convention the v2 build will expect — by setting the `extension` option:
+
+```js
+// index.js
+module.exports = {
+  name: require('./package').name,
+
+  options: {
+    cssModules: {
+      extension: 'module.css',
+    },
+  },
+};
+```
+
+Then rename your files:
+
+```
+addon/components/my-component.css → addon/components/my-component.module.css
+```
+
+## Converting to v2
+
+When you're ready to convert to the v2 addon format, follow these steps. The broader structural changes (adding Rollup, `addon/` → `src/`, new `package.json` exports) are part of the general v2 addon migration — this guide covers the CSS Modules–specific parts.
 
 ### 1. Swap dependencies
 
@@ -105,11 +154,17 @@ export default {
 
 ### 4. Move and rename files
 
-Move your component files from `addon/` to `src/` (standard v2 addon layout) and rename CSS files to `.module.css`:
+Move your component files from `addon/` to `src/` (standard v2 addon layout). If you've already renamed to `.module.css` during preparation, just move the files:
 
 ```
-addon/components/my-component.hbs → src/components/my-component.hbs
-addon/components/my-component.js  → src/components/my-component.js
+addon/components/my-component.hbs        → src/components/my-component.hbs
+addon/components/my-component.js         → src/components/my-component.js
+addon/components/my-component.module.css → src/components/my-component.module.css
+```
+
+If you haven't renamed yet, rename as you move:
+
+```
 addon/components/my-component.css → src/components/my-component.module.css
 ```
 

--- a/docs/MIGRATING-V1-APP.md
+++ b/docs/MIGRATING-V1-APP.md
@@ -2,11 +2,49 @@
 
 This guide covers migrating the CSS Modules portion of an Ember app from `ember-css-modules` (classic build) to native CSS Modules with `glimmer-local-class-transform` (Embroider + Vite).
 
-## Prerequisites
+The migration can be done in stages, so you don't need to change everything at once. Each stage produces a working app.
 
-Your app should already be on Embroider + Vite. This guide covers only the CSS Modules migration, not the broader build pipeline migration. For help migrating to Embroider, see the [Embroider migration guide](https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md).
+## Migration stages
 
-## Steps
+### Overview
+
+| Stage | Build pipeline | CSS Modules provided by |
+| --- | --- | --- |
+| **Starting point** | Classic (Broccoli) | `ember-css-modules` |
+| **Stage 1** | Embroider + Webpack | `ember-css-modules` |
+| **Stage 2** | Embroider + Vite | `glimmer-local-class-transform` |
+
+`ember-css-modules` works with both the classic Broccoli build and Embroider + Webpack. It does **not** work with Vite. This means you can migrate your build pipeline first (stages 1), confirm everything works, and then swap the CSS Modules implementation when you move to Vite (stage 2).
+
+### Stage 1: Migrate to Embroider + Webpack
+
+In this stage, you migrate your build pipeline from classic Broccoli to Embroider + Webpack. `ember-css-modules` continues to work — no CSS Modules changes are needed.
+
+This stage is not covered in detail here. See the [Embroider migration guide](https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md) for instructions. The key addition for CSS Modules is to enable `css-loader` modules support in your Embroider config:
+
+```js
+// ember-cli-build.js
+const { Webpack } = require('@embroider/webpack');
+
+return require('@embroider/compat').compatBuild(app, Webpack, {
+  // ...embroider options
+  packagerOptions: {
+    cssLoaderOptions: {
+      modules: { auto: true },
+    },
+  },
+});
+```
+
+At this point your app is on Embroider + Webpack with `ember-css-modules` still handling CSS Modules. Verify everything works before continuing.
+
+### Stage 2: Swap to glimmer-local-class-transform + Vite
+
+This is where you swap out `ember-css-modules` for native CSS Modules. This stage coincides with moving from Webpack to Vite, since `ember-css-modules` doesn't work with Vite.
+
+Follow the steps below.
+
+## Steps (Stage 2)
 
 ### 1. Swap dependencies
 

--- a/docs/MIGRATING-V1-APP.md
+++ b/docs/MIGRATING-V1-APP.md
@@ -183,12 +183,86 @@ No changes needed. `local-class` works identically with `glimmer-local-class-tra
 | `plugins` (PostCSS) | Configure PostCSS directly via `postcss.config.js` — Vite picks it up automatically. |
 | `generateScopedName` | Configure in `vite.config.mjs` under `css.modules.generateScopedName`. |
 | `intermediateOutputPath` | No equivalent (not needed with Vite). |
-| `extension` | No equivalent. Vite requires `.module.css`. |
+| `extension` | No equivalent. Vite uses the `.module.*` convention (e.g. `.module.css`, `.module.scss`). |
 | `includeExtensionInModulePath` | No equivalent (imports always use the full `.module.css` path). |
 | `postcssOptions` | Configure PostCSS directly via `postcss.config.js`. |
 | `sourceMap` | Configure via Vite's `css.devSourcemap` option. |
 | `composes` | Works natively with CSS Modules in Vite — no configuration needed. |
 | `@value` | Works natively with CSS Modules in Vite — no configuration needed. |
+
+## Apps using SCSS
+
+If your app uses SCSS with CSS Modules (via `@csstools/postcss-sass` and `postcss-scss`), the migration is straightforward because Vite has built-in Sass support and natively handles `.module.scss` files.
+
+### What changes
+
+With `ember-css-modules`, SCSS is typically processed via PostCSS plugins:
+
+```js
+// ember-cli-build.js (before)
+const sassPlugin = require('@csstools/postcss-sass')({
+  includePaths: ['app/styles', 'node_modules'],
+  silenceDeprecations: ['import', 'legacy-js-api'],
+});
+const cssParser = require('postcss-scss');
+
+cssModules: {
+  extension: 'module.scss',
+  plugins: {
+    before: [sassPlugin],
+  },
+  postcssOptions: {
+    syntax: cssParser,
+  },
+},
+```
+
+With Vite, Sass compilation is built in — you don't need PostCSS plugins for it. Configure Sass options directly in `vite.config.mjs`:
+
+```js
+// vite.config.mjs (after)
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        includePaths: ['app/styles', 'node_modules'],
+        silenceDeprecations: ['import', 'legacy-js-api'],
+      },
+    },
+  },
+  plugins: [
+    // ...ember plugins
+  ],
+});
+```
+
+Vite automatically applies CSS Modules scoping to any file with the `.module.scss` extension — no additional configuration is needed.
+
+### Config mapping
+
+| `ember-css-modules` SCSS config | Vite equivalent |
+| --- | --- |
+| `extension: 'module.scss'` | Native — Vite handles `.module.scss` out of the box |
+| `plugins.before: [sassPlugin]` | Not needed — Vite compiles Sass natively |
+| `postcssOptions.syntax: cssParser` | Not needed — Vite handles Sass→CSS before PostCSS |
+| `includePaths` | `css.preprocessorOptions.scss.includePaths` |
+| `silenceDeprecations` | `css.preprocessorOptions.scss.silenceDeprecations` |
+| `intermediateOutputPath` | No equivalent |
+
+### Transform `pathMapping`
+
+Configure `glimmer-local-class-transform` to look for `.module.scss` files instead of `.module.css`:
+
+```js
+// babel.config.cjs
+transforms: [
+  ['glimmer-local-class-transform', { pathMapping: { '(\\.g?[tj]s|\\.hbs)+$': '.module.scss' } }],
+],
+```
+
+### File naming
+
+If you're already using `.module.scss` files with `ember-css-modules` (via `extension: 'module.scss'`), no file renames are needed — the files are already in the format Vite expects.
 
 ## Custom `pathMapping`
 

--- a/docs/MIGRATING-V1-APP.md
+++ b/docs/MIGRATING-V1-APP.md
@@ -2,7 +2,7 @@
 
 This guide covers migrating the CSS Modules portion of an Ember app from `ember-css-modules` (classic build) to native CSS Modules with `glimmer-local-class-transform` (Embroider + Vite).
 
-The migration can be done in stages, so you don't need to change everything at once. Each stage produces a working app.
+The migration can be done in stages, so you don't need to change everything at once. Each stage produces a working app, and several preparation steps can be done while you're still on `ember-css-modules`.
 
 ## Migration stages
 
@@ -14,9 +14,65 @@ The migration can be done in stages, so you don't need to change everything at o
 | **Stage 1** | Embroider + Webpack | `ember-css-modules` |
 | **Stage 2** | Embroider + Vite | `glimmer-local-class-transform` |
 
-`ember-css-modules` works with both the classic Broccoli build and Embroider + Webpack. It does **not** work with Vite. This means you can migrate your build pipeline first (stages 1), confirm everything works, and then swap the CSS Modules implementation when you move to Vite (stage 2).
+`ember-css-modules` works with both the classic Broccoli build and Embroider + Webpack. It does **not** work with Vite. This means you can migrate your build pipeline first (stage 1), confirm everything works, and then swap the CSS Modules implementation when you move to Vite (stage 2).
 
-### Stage 1: Migrate to Embroider + Webpack
+Several preparation steps can be done during stage 1 (or even at the starting point) to reduce the amount of change needed when you finally swap to Vite.
+
+## Preparation (can be done before stage 2)
+
+These steps work with `ember-css-modules` on either the classic build or Embroider + Webpack. Do them incrementally at any time — each produces a working app.
+
+### Consolidate to colocated file layout
+
+If you have components using pod layout (`component/styles.css`) or classic layout (`styles/components/foo.css`), move them to colocated files alongside the component's template/JS. `ember-css-modules` already supports colocated layout, so this is a safe change:
+
+**Pod layout → colocated:**
+
+```
+app/components/my-component/styles.css → app/components/my-component.css
+```
+
+**Classic layout → colocated:**
+
+```
+app/styles/components/my-component.css → app/components/my-component.css
+```
+
+This step can be done one component at a time. Once all components use colocated layout, the remaining migration steps are simpler.
+
+### Rename CSS files to `.module.css`
+
+`ember-css-modules` supports configuring the file extension it looks for. You can rename your CSS files to `.module.css` now — matching the convention Vite will expect later — by setting the `extension` option:
+
+```js
+// ember-cli-build.js
+cssModules: {
+  extension: 'module.css',
+},
+```
+
+Then rename your files:
+
+```
+app/components/my-component.css → app/components/my-component.module.css
+```
+
+This can be done across the whole app at once, since it's a single config change plus renames.
+
+Note: for colocated components, `ember-css-modules` always includes the extension in JS import paths. After this change, JS imports would look like `import styles from 'my-app/components/my-component.module.css'` — the `.module.css` part already matches the final v2 format.
+
+### Remove `headerModules`, `footerModules`, and `virtualModules`
+
+These `cssModules` options have no equivalent in the v2 setup (see [Config differences](#config-differences)). Removing them while still on `ember-css-modules` lets you verify replacements work before the final migration:
+
+- **`headerModules` / `footerModules`** — Replace with standard CSS `@import` rules or adjust your stylesheet ordering manually.
+- **`virtualModules`** — Replace with CSS custom properties, a shared `.module.css` file with `composes`, or build-time code generation.
+
+### Migrate PostCSS config to `postcss.config.js`
+
+If you have PostCSS plugins configured via `cssModules.plugins` or `cssModules.postcssOptions`, move them to a standalone `postcss.config.js` file. Both Webpack (with appropriate loader config) and Vite pick up `postcss.config.js` automatically, so this works across all stages.
+
+## Stage 1: Migrate to Embroider + Webpack
 
 In this stage, you migrate your build pipeline from classic Broccoli to Embroider + Webpack. `ember-css-modules` continues to work — no CSS Modules changes are needed.
 
@@ -38,13 +94,11 @@ return require('@embroider/compat').compatBuild(app, Webpack, {
 
 At this point your app is on Embroider + Webpack with `ember-css-modules` still handling CSS Modules. Verify everything works before continuing.
 
-### Stage 2: Swap to glimmer-local-class-transform + Vite
+## Stage 2: Swap to glimmer-local-class-transform + Vite
 
 This is where you swap out `ember-css-modules` for native CSS Modules. This stage coincides with moving from Webpack to Vite, since `ember-css-modules` doesn't work with Vite.
 
-Follow the steps below.
-
-## Steps (Stage 2)
+If you've completed the preparation steps above, the remaining changes are:
 
 ### 1. Swap dependencies
 
@@ -78,31 +132,36 @@ module.exports = {
 };
 ```
 
-### 3. Rename CSS files to `.module.css`
+### 3. Remove remaining `cssModules:` config
 
-Vite uses the `.module.css` extension to identify CSS Modules. Rename all your component CSS files:
+Remove the `cssModules` key from your `ember-cli-build.js` entirely. If you haven't already migrated individual options during preparation, see [Config differences](#config-differences) below.
 
-**Colocated components:**
+### 4. Update JS imports
 
-```
-app/components/my-component.css → app/components/my-component.module.css
-```
+If you import styles in JavaScript, update the import paths from absolute (module-prefix-based) to relative:
 
-**Pod components** — move from the pod's `styles.css` to a colocated `.module.css` file:
+**Before:**
 
-```
-app/components/my-component/styles.css → app/components/my-component.module.css
+```js
+import styles from 'my-app/components/my-component.module.css';
 ```
 
-**Classic layout** — move from the `styles/components/` directory to colocated:
+**After:**
 
+```js
+import styles from './my-component.module.css';
 ```
-app/styles/components/my-component.css → app/components/my-component.module.css
+
+If you haven't yet renamed to `.module.css` (skipped the preparation step), you'll also need to add the extension:
+
+```js
+// Before (no extension or .css):
+import styles from 'my-app/components/my-component/styles';
+import styles from 'my-app/components/my-component.css';
+
+// After:
+import styles from './my-component.module.css';
 ```
-
-### 4. Remove `cssModules:` config
-
-Remove the `cssModules` key from your `ember-cli-build.js`. The options no longer apply — see [Config differences](#config-differences) below for details on what replaces each option.
 
 ### 5. Template syntax
 
@@ -112,24 +171,6 @@ No changes needed. `local-class` works identically with `glimmer-local-class-tra
 <div local-class="my-class">Hello</div>
 <div local-class={{this.dynamicClass}}>Hello</div>
 <div class="global" local-class="scoped">Hello</div>
-```
-
-### 6. Update JS imports
-
-If you import styles in JavaScript, update the import paths from absolute (module-prefix-based) to relative, and add the `.module.css` extension:
-
-**Before:**
-
-```js
-import styles from 'my-app/components/my-component/styles';
-// or for colocated:
-import styles from 'my-app/components/my-component.css';
-```
-
-**After:**
-
-```js
-import styles from './my-component.module.css';
 ```
 
 ## Config differences

--- a/docs/MIGRATING-V1-APP.md
+++ b/docs/MIGRATING-V1-APP.md
@@ -1,0 +1,130 @@
+# Migrating an App from ember-css-modules to glimmer-local-class-transform
+
+This guide covers migrating the CSS Modules portion of an Ember app from `ember-css-modules` (classic build) to native CSS Modules with `glimmer-local-class-transform` (Embroider + Vite).
+
+## Prerequisites
+
+Your app should already be on Embroider + Vite. This guide covers only the CSS Modules migration, not the broader build pipeline migration. For help migrating to Embroider, see the [Embroider migration guide](https://github.com/embroider-build/embroider/blob/main/PORTING-ADDONS-TO-V2.md).
+
+## Steps
+
+### 1. Swap dependencies
+
+Remove `ember-css-modules` and add `glimmer-local-class-transform`:
+
+```sh
+npm uninstall ember-css-modules
+npm install --save-dev glimmer-local-class-transform
+```
+
+### 2. Register the transform
+
+In your `babel.config.cjs`, add `glimmer-local-class-transform` to the `transforms` array of `babel-plugin-ember-template-compilation`:
+
+```js
+// babel.config.cjs
+module.exports = {
+  plugins: [
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        // ...
+        transforms: [
+          'glimmer-local-class-transform',
+          // ...other transforms
+        ],
+      },
+    ],
+    // ...other plugins
+  ],
+};
+```
+
+### 3. Rename CSS files to `.module.css`
+
+Vite uses the `.module.css` extension to identify CSS Modules. Rename all your component CSS files:
+
+**Colocated components:**
+
+```
+app/components/my-component.css → app/components/my-component.module.css
+```
+
+**Pod components** — move from the pod's `styles.css` to a colocated `.module.css` file:
+
+```
+app/components/my-component/styles.css → app/components/my-component.module.css
+```
+
+**Classic layout** — move from the `styles/components/` directory to colocated:
+
+```
+app/styles/components/my-component.css → app/components/my-component.module.css
+```
+
+### 4. Remove `cssModules:` config
+
+Remove the `cssModules` key from your `ember-cli-build.js`. The options no longer apply — see [Config differences](#config-differences) below for details on what replaces each option.
+
+### 5. Template syntax
+
+No changes needed. `local-class` works identically with `glimmer-local-class-transform`:
+
+```hbs
+<div local-class="my-class">Hello</div>
+<div local-class={{this.dynamicClass}}>Hello</div>
+<div class="global" local-class="scoped">Hello</div>
+```
+
+### 6. Update JS imports
+
+If you import styles in JavaScript, update the import paths from absolute (module-prefix-based) to relative, and add the `.module.css` extension:
+
+**Before:**
+
+```js
+import styles from 'my-app/components/my-component/styles';
+// or for colocated:
+import styles from 'my-app/components/my-component.css';
+```
+
+**After:**
+
+```js
+import styles from './my-component.module.css';
+```
+
+## Config differences
+
+| `cssModules` option | v2 equivalent |
+| --- | --- |
+| `headerModules` | No direct equivalent. Use standard CSS `@import` or adjust your stylesheet ordering manually. |
+| `footerModules` | No direct equivalent. Use standard CSS `@import` or adjust your stylesheet ordering manually. |
+| `virtualModules` | No direct equivalent. Use CSS custom properties or a shared `.module.css` file with `composes`. |
+| `plugins` (PostCSS) | Configure PostCSS directly via `postcss.config.js` — Vite picks it up automatically. |
+| `generateScopedName` | Configure in `vite.config.mjs` under `css.modules.generateScopedName`. |
+| `intermediateOutputPath` | No equivalent (not needed with Vite). |
+| `extension` | No equivalent. Vite requires `.module.css`. |
+| `includeExtensionInModulePath` | No equivalent (imports always use the full `.module.css` path). |
+| `postcssOptions` | Configure PostCSS directly via `postcss.config.js`. |
+| `sourceMap` | Configure via Vite's `css.devSourcemap` option. |
+| `composes` | Works natively with CSS Modules in Vite — no configuration needed. |
+| `@value` | Works natively with CSS Modules in Vite — no configuration needed. |
+
+## Custom `pathMapping`
+
+By default, the transform maps template files to `.module.css` files of the same name:
+
+- `my-component.gjs` → `./my-component.module.css`
+- `my-component.hbs` → `./my-component.module.css`
+
+If you want to use plain `.css` instead of `.module.css` (e.g. with a bundler that doesn't require the `.module.css` convention), you can configure `pathMapping`:
+
+```js
+// babel.config.cjs
+transforms: [
+  ['glimmer-local-class-transform', { pathMapping: { '\\.(gjs|hbs)$': '.css' } }],
+],
+```
+
+See the [`glimmer-local-class-transform` README](../packages/glimmer-local-class-transform/README.md) for full configuration options.

--- a/packages/ember-css-modules/README.md
+++ b/packages/ember-css-modules/README.md
@@ -2,6 +2,8 @@
 
 > [!IMPORTANT]
 > This package has been the core means of using CSS Modules in Ember projects for a long time, and it will continue to be maintained, but v3 is likely the final major version and this probably isn't what you want to use in new projects. See [the main README in this repository](https://github.com/salsify/ember-css-modules) for more details on the current state of CSS Modules in Ember.
+>
+> Ready to migrate? See the migration guides for [apps](../../docs/MIGRATING-V1-APP.md) and [addons](../../docs/MIGRATING-V1-ADDON.md).
 
 <details>
 <summary>Full documentation</summary>

--- a/packages/ember-css-modules/README.md
+++ b/packages/ember-css-modules/README.md
@@ -3,9 +3,8 @@
 > [!IMPORTANT]
 > This package has been the core means of using CSS Modules in Ember projects for a long time, and it will continue to be maintained, but v3 is likely the final major version and this probably isn't what you want to use in new projects. See [the main README in this repository](https://github.com/salsify/ember-css-modules) for more details on the current state of CSS Modules in Ember.
 
-<!--
-
-TODO: figure out how much of this content needs to be kept
+<details>
+<summary>Full documentation</summary>
 
 Ember-flavored support for [CSS Modules](https://github.com/css-modules/css-modules). For an overview of some of the motivations for the CSS Modules concept, see [this blog post](http://blog.salsify.com/engineering/good-fences-with-css-modules).
 
@@ -320,4 +319,4 @@ sourcemaps: {
 
 This addon supports Ember 3.28 and later, and is primarily for use in classic-build applications and v1 addons. See [the main README in this repository](https://github.com/salsify/ember-css-modules) for more details on more effective ways of using CSS Modules with Embroider and in v2 addons.
 
--->
+</details>

--- a/packages/glimmer-local-class-transform/README.md
+++ b/packages/glimmer-local-class-transform/README.md
@@ -4,8 +4,152 @@ This package provides a Glimmer template transform allowing the use of `local-cl
 
 ## Setup
 
-### Registering the Transform
+This transform is designed for use in v2 Ember apps and addons. If you're using a v1 app or the classic build pipeline, use [`ember-css-modules`](../ember-css-modules) or [`ember-local-class`](../ember-local-class) instead.
+
+### v2 Ember Apps
+
+Register the transform in your `babel.config.cjs` as part of the `babel-plugin-ember-template-compilation` transforms:
+
+```js
+module.exports = {
+  plugins: [
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        // ...
+        transforms: [
+          'glimmer-local-class-transform',
+          // ...other transforms
+        ],
+      },
+    ],
+    // ...other plugins
+  ],
+};
+```
+
+### v2 Ember Addons
+
+For v2 addons using Rollup, add the transform to your `babel.publish.config.cjs`:
+
+```js
+module.exports = {
+  plugins: [
+    '@embroider/addon-dev/template-colocation-plugin',
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        targetFormat: 'hbs',
+        transforms: ['glimmer-local-class-transform'],
+      },
+    ],
+    // ...other plugins
+  ],
+};
+```
+
+Make sure your Rollup babel plugin includes `.hbs` in its extensions so that standalone template files are processed:
+
+```js
+babel({
+  extensions: ['.hbs', '.js', '.gjs'],
+  babelHelpers: 'bundled',
+  configFile: './babel.publish.config.cjs',
+}),
+```
 
 ### Config
 
+To pass configuration options, use the array form instead of the string shorthand:
+
+```js
+transforms: [
+  ['glimmer-local-class-transform', { pathMapping: { '\\.gjs$': '.css' } }],
+],
+```
+
+The following options are available:
+
+#### `pathMapping`
+
+A mapping where each key is a regular expression and each value is a replacement string, used to determine the CSS module path for a given template file. The first matching pattern is used.
+
+Replacement strings may use `$1`, `$2`, etc. to reference capture groups from the regular expression.
+
+**Default:** `{ '(\\.g?[tj]s|\\.hbs)+$': '.module.css' }`
+
+This default maps any `.js`, `.ts`, `.gjs`, `.gts`, or `.hbs` file to a `.module.css` file of the same name in the same directory.
+
+Example — map `.gjs` and `.hbs` files to plain `.css`:
+
+```js
+pathMapping: {
+  '\\.(gjs|hbs)$': '.css',
+}
+```
+
+#### `runtimeModule`
+
+The module specifier from which runtime helpers (`classNames`, `join`) are imported.
+
+**Default:** `'glimmer-local-class-transform/-runtime'`
+
+You generally don't need to change this unless you're providing your own runtime implementation.
+
 ## Usage
+
+### Static class names
+
+```hbs
+<div local-class="my-class"></div>
+```
+
+This resolves `my-class` from the co-located CSS module and applies the scoped class name.
+
+### Dynamic class names
+
+```hbs
+<div local-class={{someProperty}}></div>
+```
+
+### Mixed static and dynamic
+
+```hbs
+<div local-class="foo {{bar}}"></div>
+```
+
+### Combined with `class`
+
+`local-class` and `class` can be used together on the same element. The resolved local classes are appended to the regular classes:
+
+```hbs
+<div class="global-class" local-class="scoped-class"></div>
+```
+
+### The `local-class` helper
+
+For more control, you can use `local-class` as a helper directly in a `class` attribute. This also supports a `from` argument to reference a CSS module from a different path:
+
+```hbs
+<div class={{local-class "foo"}}></div>
+<div class="bar {{local-class "foo" from="@some/other-module"}}"></div>
+```
+
+## How It Works
+
+At compile time, the transform rewrites templates that use `local-class`:
+
+1. It determines the CSS module path for the current template using `pathMapping` (e.g. `my-component.gjs` → `./my-component.module.css`).
+2. It imports the CSS module's default export (the class name mapping object) and the `classNames` runtime helper.
+3. It replaces `local-class` usages with calls to `classNames(styles, ...)`, which looks up each class name in the CSS module mapping and returns the corresponding scoped class names.
+
+For example, `<div local-class="foo">` is transformed into the equivalent of:
+
+```js
+import styles from './my-component.module.css';
+import { classNames } from 'glimmer-local-class-transform/-runtime';
+```
+
+```hbs
+<div class={{classNames styles "foo"}}></div>
+```

--- a/packages/rollup-plugin-preprocess-css-modules/README.md
+++ b/packages/rollup-plugin-preprocess-css-modules/README.md
@@ -1,13 +1,15 @@
 # `rollup-plugin-preprocess-css-modules`
 
-TODO
+A Rollup plugin that preprocesses [CSS Modules](https://github.com/css-modules/css-modules) at build time, replacing `.module.css` imports with plain CSS and a static JS mapping object.
+
+This is primarily useful for **v2 Ember addons** that want to use CSS Modules as an internal implementation detail while publishing standard CSS that doesn't require CSS Module support from consuming apps.
+
+## What It Does
+
+Given a CSS Module import like this:
 
 ```js
-// my-component.js
 import styles from './my-component.module.css';
-export default `
-  <h1 class="${styles.title}">Hello, world!</h1>
-`;
 ```
 
 ```css
@@ -17,15 +19,7 @@ export default `
 }
 ```
 
-===>
-
-```js
-// my-component.js
-import styles from './my-component.module.css.js';
-export default `
-  <h1 class="${styles.title}">Hello, world!</h1>
-`;
-```
+The plugin produces two output files:
 
 ```js
 // my-component.module.css.js
@@ -42,3 +36,52 @@ export default {
   color: darkblue;
 }
 ```
+
+The original import is rewritten to point at the generated `.module.css.js` file, so consuming code continues to work unchanged — but the published output is plain CSS with no CSS Modules processing required.
+
+## Setup
+
+Add the plugin to your `rollup.config.mjs`:
+
+```js
+import { preprocessCSSModules } from 'rollup-plugin-preprocess-css-modules';
+
+export default {
+  plugins: [
+    // ...other plugins
+    preprocessCSSModules(),
+    // If using @embroider/addon-dev, keep the emitted .css files in output:
+    addon.keepAssets(['**/*.css']),
+  ],
+};
+```
+
+## Config
+
+All options are optional:
+
+```js
+preprocessCSSModules({
+  include: '**/*.module.css',
+  generateScopedName: (name, filename, css) => `_${name}_abc123_`,
+  getOutputFilename: (filename) => filename.replace(/\.module\.css$/, '.css'),
+})
+```
+
+### `include`
+
+A glob pattern controlling which CSS files are treated as CSS Modules.
+
+**Default:** `'**/*.module.css'`
+
+### `generateScopedName`
+
+A function that determines the scoped class name for each local identifier. Receives the original class name, the source filename, and the full CSS content.
+
+**Default:** Uses the [postcss-modules](https://github.com/css-modules/postcss-modules) default scoping.
+
+### `getOutputFilename`
+
+A function that maps the input `.module.css` path to the output `.css` path.
+
+**Default:** Strips `.module` from the filename (e.g. `foo.module.css` → `foo.css`).

--- a/packages/rollup-plugin-preprocess-css-modules/README.md
+++ b/packages/rollup-plugin-preprocess-css-modules/README.md
@@ -2,7 +2,7 @@
 
 A Rollup plugin that preprocesses [CSS Modules](https://github.com/css-modules/css-modules) at build time, replacing `.module.css` imports with plain CSS and a static JS mapping object.
 
-This is primarily useful for **v2 Ember addons** that want to use CSS Modules as an internal implementation detail while publishing standard CSS that doesn't require CSS Module support from consuming apps.
+This is primarily useful for component libraries that want to use CSS Modules as an internal implementation detail while publishing standard CSS that doesn't require CSS Module support from consuming apps.
 
 ## What It Does
 


### PR DESCRIPTION
## Summary

- Add migration guides for apps and addons moving from `ember-css-modules` to the standalone packages (`glimmer-local-class-transform`, `rollup-plugin-preprocess-css-modules`)
- Flesh out READMEs for `glimmer-local-class-transform` and `rollup-plugin-preprocess-css-modules`
- Make `ember-css-modules` README docs expandable
- Link migration guides from root README and `ember-css-modules` deprecation notice

### Migration guides

Both guides include preparation steps that can be done incrementally before the final migration:

- **App guide** (`docs/MIGRATING-V1-APP.md`): Staged path from classic Broccoli → Embroider+Webpack → Embroider+Vite, with prep steps (colocate files, rename to `.module.css`, remove legacy config, migrate PostCSS). Includes a dedicated section for apps using SCSS via PostCSS plugins.
- **Addon guide** (`docs/MIGRATING-V1-ADDON.md`): Prep steps while still v1 (colocate files, rename to `.module.css`), then v2 conversion steps

## Test plan

- [ ] Verify all code snippets and config examples match the actual test-packages
- [ ] Confirm links between docs are correct
- [ ] Review migration steps for accuracy and completeness